### PR TITLE
Updated repo details component to consume new ExpandedRepoInfo api changes

### DIFF
--- a/src/__tests__/Shared/PreviewCard.test.js
+++ b/src/__tests__/Shared/PreviewCard.test.js
@@ -35,7 +35,7 @@ describe('Preview card component', () => {
     const cardTitle = await screen.findByText('alpine');
     expect(cardTitle).toBeInTheDocument();
     userEvent.click(cardTitle);
-    expect(mockedUsedNavigate).toBeCalledWith(`/image/${mockImage.name}`, expect.anything());
+    expect(mockedUsedNavigate).toBeCalledWith(`/image/${mockImage.name}`);
   });
 });
 

--- a/src/__tests__/Shared/RepoCard.test.js
+++ b/src/__tests__/Shared/RepoCard.test.js
@@ -47,7 +47,7 @@ describe('Repo card component', () => {
     const cardTitle = await screen.findByText('alpine');
     expect(cardTitle).toBeInTheDocument();
     userEvent.click(cardTitle);
-    expect(mockedUsedNavigate).toBeCalledWith(`/image/${mockImage.name}`, expect.anything());
+    expect(mockedUsedNavigate).toBeCalledWith(`/image/${mockImage.name}`);
   });
 });
 

--- a/src/__tests__/Shared/RepoCard.test.js
+++ b/src/__tests__/Shared/RepoCard.test.js
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import PreviewCard from 'components/PreviewCard';
 import userEvent from '@testing-library/user-event';
+import RepoCard from 'components/RepoCard';
 
 
 // usenavigate mock
@@ -31,7 +32,7 @@ afterEach(() => {
 
 describe('Repo card component', () => {
   it('navigates to repo page when clicked',async () => {
-    render(<PreviewCard
+    render(<RepoCard
         name={mockImage.name}
         version={mockImage.latestVersion}
         description={mockImage.description}

--- a/src/api.js
+++ b/src/api.js
@@ -62,7 +62,7 @@ const api = {
 
 const endpoints = {
     imageList: '/v2/_zot/ext/search?query={ImageListWithLatestTag () { Name Latest LastUpdated Description Licenses Vendor Size Labels}}',
-    detailedRepoInfo: (name) => `/v2/_zot/ext/search?query={ExpandedRepoInfo(repo:"${name}"){Manifests {Digest Tag Layers {Size Digest}}}}`
+    detailedRepoInfo: (name) => `/v2/_zot/ext/search?query={ExpandedRepoInfo(repo:"${name}"){Manifests {Digest Tag Layers {Size Digest}} Summary {Name LastUpdated Size Platforms {Os Arch} Vendors NewestTag {Tag}}}}`
 }
 
 export {api, endpoints};

--- a/src/components/PreviewCard.jsx
+++ b/src/components/PreviewCard.jsx
@@ -1,6 +1,5 @@
 import { Card, CardActionArea, CardContent, CardMedia, Grid, Stack, Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
-import { DateTime } from 'luxon';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import CheckCircleOutlineOutlinedIcon from '@mui/icons-material/CheckCircleOutlineOutlined';
@@ -64,10 +63,10 @@ const useStyles = makeStyles(() => ({
 function PreviewCard(props) {
   const classes = useStyles();
   const navigate = useNavigate();
-  const { name, lastUpdated } = props;
+  const { name } = props;
 
   const goToDetails = (repo) => {
-    navigate(`/image/${name}`, { state: { lastDate: (lastUpdated ? DateTime.fromISO(lastUpdated) : DateTime.now().minus({ days: 1 })).toRelative({ unit: 'days' }) } });
+    navigate(`/image/${name}`);
   };
 
   const verifiedCheck = () => {

--- a/src/components/RepoCard.jsx
+++ b/src/components/RepoCard.jsx
@@ -75,7 +75,7 @@ function RepoCard(props) {
   const { name, vendor, description, lastUpdated, downloads, rating, version } = props;
 
   const goToDetails = (repo) => {
-    navigate(`/image/${name}`, { state: { lastDate: (lastUpdated ? DateTime.fromISO(lastUpdated) : DateTime.now().minus({ days: 1 })).toRelative({ unit: 'days' }) } });
+    navigate(`/image/${name}`);
   }
 
   const verifiedCheck = () => {

--- a/src/components/RepoDetailsMetadata.jsx
+++ b/src/components/RepoDetailsMetadata.jsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, Grid, Typography } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
+import { DateTime } from 'luxon';
 import React from 'react';
 import transform from '../utilities/transform';
 
@@ -34,8 +35,8 @@ const useStyles = makeStyles(() => ({
 
 function RepoDetailsMetadata (props) {
   const classes = useStyles();
-  const {name, repoURL, weeklyDownloads, lastUpdated, size, filesNr, latestTag, issues, prs} = props;
-
+  const {repoURL, weeklyDownloads, lastUpdated, size, filesNr} = props;
+  const lastDate = (lastUpdated ? DateTime.fromISO(lastUpdated) : DateTime.now().minus({ days: 1 })).toRelative({ unit: 'days' })
   return (
     <Grid container spacing={1}>
       <Grid container item xs={12}>
@@ -59,69 +60,25 @@ function RepoDetailsMetadata (props) {
           <Card variant="outlined" className={classes.card}>
             <CardContent>
               <Typography variant="body2" align="left" className={classes.metadataHeader}>Last publish</Typography>
-              <Typography variant="body1" className={classes.metadataBody}>{lastUpdated || `35 days ago`}</Typography>
+              <Typography variant="body1" className={classes.metadataBody}>{lastDate || `35 days ago`}</Typography>
             </CardContent>
           </Card>
         </Grid>
         <Grid item xs={6}>
           <Card variant="outlined" className={classes.card}>
             <CardContent>
-              <Typography variant="body2" align="left" className={classes.metadataHeader}>Image size</Typography>
+              <Typography variant="body2" align="left" className={classes.metadataHeader}>Total size</Typography>
               <Typography variant="body1" className={classes.metadataBody}>{transform.formatBytes(size) || `----`}</Typography>
             </CardContent>
           </Card>
         </Grid>
       </Grid>
       <Grid container item xs={12} spacing={2}>
-        <Grid item xs={6}>
-          <Card variant="outlined" className={classes.card}>
-            <CardContent>
-              <Typography variant="body2" align="left" className={classes.metadataHeader}>Last publish</Typography>
-              <Typography variant="body1" className={classes.metadataBody}>{lastUpdated || `----`}</Typography>
-            </CardContent>
-          </Card>
-        </Grid>
-        <Grid item xs={6}>
-          <Card variant="outlined" className={classes.card}>
-            <CardContent>
-              <Typography variant="body2" align="left" className={classes.metadataHeader}>Image size</Typography>
-              <Typography variant="body1" className={classes.metadataBody}>{size || `----`}</Typography>
-            </CardContent>
-          </Card>
-        </Grid>
-      </Grid>
-      <Grid container item xs={12} spacing={2}>
-        <Grid item xs={6}>
+        <Grid item xs={12}>
           <Card variant="outlined" className={classes.card}>
             <CardContent>
               <Typography variant="body2" align="left" className={classes.metadataHeader}>Files</Typography>
               <Typography variant="body1" align="left" className={classes.metadataBody}>{filesNr || `----`}</Typography>
-            </CardContent>
-          </Card>
-        </Grid>
-        <Grid item xs={6}>
-          <Card variant="outlined" className={classes.card}>
-            <CardContent>
-              <Typography variant="body2" align="left" className={classes.metadataHeader}>Latest tag</Typography>
-              <Typography variant="body1" align="left" className={classes.metadataBody}>{latestTag || `----`}</Typography>
-            </CardContent>
-          </Card>
-        </Grid>
-      </Grid>
-      <Grid container item xs={12} spacing={2}>
-        <Grid item xs={6}>
-          <Card variant="outlined" className={classes.card}>
-            <CardContent>
-              <Typography variant="body2" align="left" className={classes.metadataHeader}>Issues</Typography>
-              <Typography variant="body1" align="left" className={classes.metadataBody}>{issues || `----`}</Typography>
-            </CardContent>
-          </Card>
-        </Grid>
-        <Grid item xs={6}>
-          <Card variant="outlined" className={classes.card}>
-            <CardContent>
-              <Typography variant="body2" align="left" className={classes.metadataHeader}>Pull requests</Typography>
-              <Typography variant="body1" align="left" className={classes.metadataBody}>{prs || `----`}</Typography>
             </CardContent>
           </Card>
         </Grid>


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
Closes #32 

**What does this PR do / Why do we need it**:
Consumes new zot ExpandedRepoInfo endpoint extensions.


**Testing done on this change**:
Updated relevant tests


**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
Depends on latest version of zot

**Does this PR introduce any user-facing change?**:

```release-note
- Updated Repo Details component to use platforms returned by api to generate platform chips
- Updated styling in Repo Details component to newest mocks
- Updated styling in RepoMetadata component to match newest mocks
- Updated data displayed in RepoMetadata component to use real data returned from api
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
