### PR TITLE
Updated front-end code to replace ImageListWithLatestTag with RepoListWithNewestImage

### DIFF
--- a/src/__tests__/Explore/Explore.test.js
+++ b/src/__tests__/Explore/Explore.test.js
@@ -16,48 +16,44 @@ const StateExploreWrapper = (props) => {
   return (<Explore data={data} keywords={''} updateData={useData} />)
 }
 const mockImageList = {
-  ImageListWithLatestTag: [
+  RepoListWithNewestImage: [
     {
-      "Name": "alpine",
-      "Latest": "latest",
-      "LastUpdated": "2022-05-23T19:19:30.413290187Z",
-      "Description": "",
-      "Licenses": "",
-      "Vendor": "",
-      "Size": "585",
-      "Labels": ""
+        "NewestImage": {
+            "RepoName": "alpine",
+            "Tag": "latest",
+            "LastUpdated": "2022-08-09T17:19:53.274069586Z",
+            "Description": "w",
+            "Licenses": "",
+            "Vendor": "",
+            "Size": "2806985",
+            "Labels": ""
+        }
     },
     {
-      "Name": "buildah",
-      "Latest": "latest",
-      "LastUpdated": "2022-05-06T10:11:58Z",
-      "Description": "",
-      "Licenses": "",
-      "Vendor": "",
-      "Size": "4440",
-      "Labels": ""
+        "NewestImage": {
+            "RepoName": "mongo",
+            "Tag": "latest",
+            "LastUpdated": "2022-08-02T01:30:49.193203152Z",
+            "Description": "",
+            "Licenses": "",
+            "Vendor": "",
+            "Size": "231383863",
+            "Labels": ""
+        }
     },
     {
-      "Name": "redis",
-      "Latest": "latest",
-      "LastUpdated": "2022-06-23T00:20:27.020952309Z",
-      "Description": "",
-      "Licenses": "",
-      "Vendor": "",
-      "Size": "6591",
-      "Labels": ""
-    },
-    {
-      "Name": "ubuntu",
-      "Latest": "latest",
-      "LastUpdated": "2022-06-06T22:21:25.961828386Z",
-      "Description": "",
-      "Licenses": "",
-      "Vendor": "",
-      "Size": "579",
-      "Labels": ""
+        "NewestImage": {
+            "RepoName": "nodeUnique",
+            "Tag": "latest",
+            "LastUpdated": "2022-08-23T00:20:40.144281895Z",
+            "Description": "",
+            "Licenses": "",
+            "Vendor": "",
+            "Size": "369311301",
+            "Labels": ""
+        }
     }
-  ]
+]
 };
 afterEach(() => {
   // restore the spy created with spyOn
@@ -71,9 +67,8 @@ describe('Explore component', () => {
     jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: { data: mockImageList } })
     render(<StateExploreWrapper/>);
     expect(await screen.findByText(/alpine/i)).toBeInTheDocument();
-    expect(await screen.findByText(/buildah/i)).toBeInTheDocument();
-    expect(await screen.findByText(/redis/i)).toBeInTheDocument();
-    expect(await screen.findByText(/ubuntu/i)).toBeInTheDocument();
+    expect(await screen.findByText(/mongo/i)).toBeInTheDocument();
+    expect(await screen.findByText(/nodeUnique/i)).toBeInTheDocument();
   });
 
   it('should log an error when data can\'t be fetched', async() => {

--- a/src/__tests__/HomePage/Home.test.js
+++ b/src/__tests__/HomePage/Home.test.js
@@ -16,48 +16,44 @@ const StateHomeWrapper = (props) => {
   return (<Home data={data} keywords={''} updateData={useData} />)
 }
 const mockImageList = {
-  ImageListWithLatestTag: [
+  RepoListWithNewestImage: [
     {
-      "Name": "alpine",
-      "Latest": "latest",
-      "LastUpdated": "2022-05-23T19:19:30.413290187Z",
-      "Description": "",
-      "Licenses": "",
-      "Vendor": "",
-      "Size": "585",
-      "Labels": ""
+        "NewestImage": {
+            "RepoName": "alpine",
+            "Tag": "latest",
+            "LastUpdated": "2022-08-09T17:19:53.274069586Z",
+            "Description": "",
+            "Licenses": "",
+            "Vendor": "",
+            "Size": "2806985",
+            "Labels": ""
+        }
     },
     {
-      "Name": "buildah",
-      "Latest": "latest",
-      "LastUpdated": "2022-05-06T10:11:58Z",
-      "Description": "",
-      "Licenses": "",
-      "Vendor": "",
-      "Size": "4440",
-      "Labels": ""
+        "NewestImage": {
+            "RepoName": "mongo",
+            "Tag": "latest",
+            "LastUpdated": "2022-08-02T01:30:49.193203152Z",
+            "Description": "",
+            "Licenses": "",
+            "Vendor": "",
+            "Size": "231383863",
+            "Labels": ""
+        }
     },
     {
-      "Name": "redis",
-      "Latest": "latest",
-      "LastUpdated": "2022-06-23T00:20:27.020952309Z",
-      "Description": "",
-      "Licenses": "",
-      "Vendor": "",
-      "Size": "6591",
-      "Labels": ""
-    },
-    {
-      "Name": "ubuntu",
-      "Latest": "latest",
-      "LastUpdated": "2022-06-06T22:21:25.961828386Z",
-      "Description": "",
-      "Licenses": "",
-      "Vendor": "",
-      "Size": "579",
-      "Labels": ""
+        "NewestImage": {
+            "RepoName": "node",
+            "Tag": "latest",
+            "LastUpdated": "2022-08-23T00:20:40.144281895Z",
+            "Description": "",
+            "Licenses": "",
+            "Vendor": "",
+            "Size": "369311301",
+            "Labels": ""
+        }
     }
-  ]
+]
 };
 afterEach(() => {
   // restore the spy created with spyOn
@@ -71,9 +67,8 @@ describe('Home component', () => {
     jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: { data: mockImageList } })
     render(<StateHomeWrapper/>);
     await waitFor(() => expect(screen.getAllByText(/alpine/i)).toHaveLength(3));
-    await waitFor(() => expect(screen.getAllByText(/buildah/i)).toHaveLength(3));
-    await waitFor(() => expect(screen.getAllByText(/redis/i)).toHaveLength(1));
-    await waitFor(() => expect(screen.getAllByText(/ubuntu/i)).toHaveLength(1));
+    await waitFor(() => expect(screen.getAllByText(/mongo/i)).toHaveLength(3));
+    await waitFor(() => expect(screen.getAllByText(/node/i)).toHaveLength(5));
   });
 
   it('should log an error when data can\'t be fetched', async() => {

--- a/src/api.js
+++ b/src/api.js
@@ -61,8 +61,8 @@ const api = {
 };
 
 const endpoints = {
-    imageList: '/v2/_zot/ext/search?query={ImageListWithLatestTag () { Name Latest LastUpdated Description Licenses Vendor Size Labels}}',
-    detailedRepoInfo: (name) => `/v2/_zot/ext/search?query={ExpandedRepoInfo(repo:"${name}"){Manifests {Digest Tag Layers {Size Digest}} Summary {Name LastUpdated Size Platforms {Os Arch} Vendors NewestTag {Tag}}}}`
+    imageList: '/v2/_zot/ext/search?query={RepoListWithNewestImage () { NewestImage {RepoName Tag LastUpdated Description Licenses Vendor Size Labels} }}',
+    detailedRepoInfo: (name) => `/v2/_zot/ext/search?query={ExpandedRepoInfo(repo:"${name}"){Images {Digest Tag Layers {Size Digest}} Summary {Name LastUpdated Size Platforms {Os Arch} Vendors NewestTag {Tag}}}}`
 }
 
 export {api, endpoints};

--- a/src/components/Explore.jsx
+++ b/src/components/Explore.jsx
@@ -48,11 +48,11 @@ function Explore ({ keywords, data, updateData }) {
         api.get(`${host()}${endpoints.imageList}`)
           .then(response => {
             if (response.data && response.data.data) {
-                let imageList = response.data.data.ImageListWithLatestTag;
+                let imageList = response.data.data.RepoListWithNewestImage.NewestImage;
                 let imagesData = imageList.map((image) => {
                     return {
-                        name: image.Name,
-                        latestVersion: image.Latest,
+                        name: image.RepoName,
+                        latestVersion: image.Tag,
                         tags: image.Labels,
                         description: image.Description,
                         licenses: image.Licenses,

--- a/src/components/Explore.jsx
+++ b/src/components/Explore.jsx
@@ -48,17 +48,17 @@ function Explore ({ keywords, data, updateData }) {
         api.get(`${host()}${endpoints.imageList}`)
           .then(response => {
             if (response.data && response.data.data) {
-                let imageList = response.data.data.RepoListWithNewestImage.NewestImage;
+                let imageList = response.data.data.RepoListWithNewestImage;
                 let imagesData = imageList.map((image) => {
                     return {
-                        name: image.RepoName,
-                        latestVersion: image.Tag,
-                        tags: image.Labels,
-                        description: image.Description,
-                        licenses: image.Licenses,
-                        size: image.Size,
-                        vendor: image.Vendor,
-                        lastUpdated: image.LastUpdated
+                        name: image.NewestImage.RepoName,
+                        latestVersion: image.NewestImage.Tag,
+                        tags: image.NewestImage.Labels,
+                        description: image.NewestImage.Description,
+                        licenses: image.NewestImage.Licenses,
+                        size: image.NewestImage.Size,
+                        vendor: image.NewestImage.Vendor,
+                        lastUpdated: image.NewestImage.LastUpdated
                     };
                 });
                 updateData(imagesData);

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -57,17 +57,17 @@ function Home ({ keywords, data, updateData }) {
     api.get(`${host()}${endpoints.imageList}`)
       .then(response => {
         if (response.data && response.data.data) {
-            let imageList = response.data.data.ImageListWithLatestTag;
+            let imageList = response.data.data.RepoListWithNewestImage;
             let imagesData = imageList.map((image) => {
                 return {
-                    name: image.Name,
-                    latestVersion: image.Latest,
-                    tags: image.Labels,
-                    description: image.Description,
-                    licenses: image.Licenses,
-                    size: image.Size,
-                    vendor: image.Vendor,
-                    lastUpdated: image.LastUpdated
+                    name: image.NewestImage.RepoName,
+                    latestVersion: image.NewestImage.Tag,
+                    tags: image.NewestImage.Labels,
+                    description: image.NewestImage.Description,
+                    licenses: image.NewestImage.Licenses,
+                    size: image.NewestImage.Size,
+                    vendor: image.NewestImage.Vendor,
+                    lastUpdated: image.NewestImage.LastUpdated
                 };
             });
             updateData(imagesData);


### PR DESCRIPTION
Signed-off-by: Amelia-Maria Breda <ameliamaria.breda@dxc.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
ui
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Closes #31

**What does this PR do / Why do we need it**:
Update front-end code to leverage RepoSummary returned by ImageListWithLatestTag

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
Depends on latest version of zot

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
