### PR TITLE
Removed 'Quickstart' and added for each N/A the property that we don't have data for in ui 

### DIFF
--- a/src/components/RepoCard.jsx
+++ b/src/components/RepoCard.jsx
@@ -166,7 +166,7 @@ function RepoCard(props) {
   };
 
   const getVendor = () => {
-    return `${vendor || 'N/A'} •`;
+    return `${vendor || 'N/A NewestImage.Vendor'} •`;
   };
   const getVersion = () => {
     return `published ${version} •`;
@@ -200,7 +200,7 @@ function RepoCard(props) {
                 {/* <Chip label="Verified licensee" sx={{ backgroundColor: "#E8F5E9", color: "#388E3C" }} variant="filled" onDelete={() => { return }} deleteIcon={vulnerabilityCheck()} /> */}
               </Stack>
               <Typography className={classes.versionLast} pt={1} sx={{ fontSize: 12 }} gutterBottom noWrap>
-                {description || 'N/A'}
+                {description || 'N/A NewestImage.Description'}
               </Typography>
               <Stack alignItems="center" direction="row" spacing={2} pt={1}>
                 {platformChips()}

--- a/src/components/RepoCard.jsx
+++ b/src/components/RepoCard.jsx
@@ -166,7 +166,7 @@ function RepoCard(props) {
   };
 
   const getVendor = () => {
-    return `${vendor || 'N/A NewestImage.Vendor'} •`;
+    return `${vendor || 'Vendor not available'} •`;
   };
   const getVersion = () => {
     return `published ${version} •`;
@@ -200,7 +200,7 @@ function RepoCard(props) {
                 {/* <Chip label="Verified licensee" sx={{ backgroundColor: "#E8F5E9", color: "#388E3C" }} variant="filled" onDelete={() => { return }} deleteIcon={vulnerabilityCheck()} /> */}
               </Stack>
               <Typography className={classes.versionLast} pt={1} sx={{ fontSize: 12 }} gutterBottom noWrap>
-                {description || 'N/A NewestImage.Description'}
+                {description || 'Description not available'}
               </Typography>
               <Stack alignItems="center" direction="row" spacing={2} pt={1}>
                 {platformChips()}

--- a/src/components/RepoDetails.jsx
+++ b/src/components/RepoDetails.jsx
@@ -222,7 +222,7 @@ function RepoDetails() {
           >
             {
               // @ts-ignore
-              repoDetailData.description || 'N/A NewestImage.Description'
+              repoDetailData.description || 'Description not available'
             }
           </Typography>
         </CardContent>
@@ -281,7 +281,7 @@ function RepoDetails() {
                   >
                     {
                       // @ts-ignore
-                      repoDetailData?.title || 'N/A NewestImage.Title'
+                      repoDetailData?.title || 'Title not available'
                     }
                   </Typography>
                   <Stack alignItems="center" sx={{ paddingLeft: '4rem' }} direction="row" spacing={2} pt={1}>

--- a/src/components/RepoDetails.jsx
+++ b/src/components/RepoDetails.jsx
@@ -210,9 +210,6 @@ function RepoDetails() {
     return (
       <Card className={classes.card} data-testid="overview-container">
         <CardContent>
-          <Typography variant="h4" align="left">
-            Quickstart
-          </Typography>
           <Typography
             variant="body1"
             sx={{
@@ -225,7 +222,7 @@ function RepoDetails() {
           >
             {
               // @ts-ignore
-              repoDetailData.description || 'N/A'
+              repoDetailData.description || 'N/A NewestImage.Description'
             }
           </Typography>
         </CardContent>
@@ -284,7 +281,7 @@ function RepoDetails() {
                   >
                     {
                       // @ts-ignore
-                      repoDetailData?.title || 'N/A'
+                      repoDetailData?.title || 'N/A NewestImage.Title'
                     }
                   </Typography>
                   <Stack alignItems="center" sx={{ paddingLeft: '4rem' }} direction="row" spacing={2} pt={1}>

--- a/src/components/RepoDetailsMetadata.jsx
+++ b/src/components/RepoDetailsMetadata.jsx
@@ -49,7 +49,7 @@ function RepoDetailsMetadata(props) {
               Repository
             </Typography>
             <Typography variant="body1" align="left" className={classes.metadataBody}>
-              {repoURL || `N/A Source`}
+              {repoURL || `not available`}
             </Typography>
           </CardContent>
         </Card>
@@ -61,7 +61,7 @@ function RepoDetailsMetadata(props) {
               Total downloads
             </Typography>
             <Typography variant="body1" align="left" className={classes.metadataBody}>
-              {totalDownloads || `N/A DownloadCount`}
+              {totalDownloads || `not available`}
             </Typography>
           </CardContent>
         </Card>

--- a/src/components/RepoDetailsMetadata.jsx
+++ b/src/components/RepoDetailsMetadata.jsx
@@ -49,7 +49,7 @@ function RepoDetailsMetadata(props) {
               Repository
             </Typography>
             <Typography variant="body1" align="left" className={classes.metadataBody}>
-              {repoURL || `N/A`}
+              {repoURL || `N/A Source`}
             </Typography>
           </CardContent>
         </Card>
@@ -61,7 +61,7 @@ function RepoDetailsMetadata(props) {
               Total downloads
             </Typography>
             <Typography variant="body1" align="left" className={classes.metadataBody}>
-              {totalDownloads || `N/A`}
+              {totalDownloads || `N/A DownloadCount`}
             </Typography>
           </CardContent>
         </Card>

--- a/src/components/TagDetails.jsx
+++ b/src/components/TagDetails.jsx
@@ -248,7 +248,7 @@ function TagDetails() {
             <Grid item xs={4}>
               <Stack direction="row">
                 <Grid item xs={10}>
-                  <Typography variant="body1" sx={{ color: '#52637A', fontSize: '1rem', paddingTop: '0.5rem' }}>
+                  <Typography variant="body1" sx={{ color: '#52637A', fontSize: '1rem', paddingTop: '0.75rem' }}>
                     Copy and pull to pull this image
                   </Typography>
                 </Grid>

--- a/src/components/Tags.jsx
+++ b/src/components/Tags.jsx
@@ -97,7 +97,7 @@ function TagCard(props) {
             Last pushed
           </Typography>
           <Typography variant="caption" sx={{ fontWeight: '600', fontSize: '0.8125rem' }}>
-            {lastDate || '---'} by {vendors || 'N/A Summary?.Vendors'}
+            {lastDate || 'Date not available'} by {vendors[0] || 'Vendor not available'}
           </Typography>
         </Stack>
 
@@ -187,7 +187,6 @@ export default function Tags(props) {
   const classes = useStyles();
   const { data } = props;
   const { images, lastUpdated, vendors, size, platforms } = data;
-  console.log(JSON.stringify(data));
 
   return (
     <Card className={classes.tagCard} data-testid="tags-container">

--- a/src/components/Tags.jsx
+++ b/src/components/Tags.jsx
@@ -97,7 +97,7 @@ function TagCard(props) {
             Last pushed
           </Typography>
           <Typography variant="caption" sx={{ fontWeight: '600', fontSize: '0.8125rem' }}>
-            {lastDate || '----'} by {vendors || 'N/A'}
+            {lastDate || '---'} by {vendors || 'N/A Summary?.Vendors'}
           </Typography>
         </Stack>
 
@@ -187,6 +187,7 @@ export default function Tags(props) {
   const classes = useStyles();
   const { data } = props;
   const { images, lastUpdated, vendors, size, platforms } = data;
+  console.log(JSON.stringify(data));
 
   return (
     <Card className={classes.tagCard} data-testid="tags-container">


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Closes #125 
Closes #128 

**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
