### PR TITLE
fix: Change display of uses/used by, cleanup repocard usage

### DIFF
--- a/src/__tests__/Shared/RepoCard.test.js
+++ b/src/__tests__/Shared/RepoCard.test.js
@@ -35,14 +35,9 @@ describe('Repo card component', () => {
         name={mockImage.name}
         version={mockImage.latestVersion}
         description={mockImage.description}
-        tags={mockImage.tags}
         vendor={mockImage.vendor}
-        size={mockImage.size}
-        licenses={mockImage.licenses}
         key={1}
-        data={mockImage}
         lastUpdated={mockImage.lastUpdated}
-        shown={true}
       />
     );
     const cardTitle = await screen.findByText('alpine');

--- a/src/__tests__/TagPage/DependsOn.test.js
+++ b/src/__tests__/TagPage/DependsOn.test.js
@@ -51,7 +51,7 @@ describe('Dependencies tab', () => {
     // @ts-ignore
     jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: mockDependenciesList });
     render(<RouterDependsWrapper />);
-    expect(await screen.findAllByRole('link')).toHaveLength(4);
+    expect(await screen.findAllByText(/published/i)).toHaveLength(4);
   });
 
   it('renders no dependencies if there are not any', async () => {

--- a/src/__tests__/TagPage/IsDependentOn.test.js
+++ b/src/__tests__/TagPage/IsDependentOn.test.js
@@ -51,7 +51,7 @@ describe('Dependents tab', () => {
     // @ts-ignore
     jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: mockDependentsList });
     render(<RouterDependsWrapper />);
-    expect(await screen.findAllByRole('link')).toHaveLength(4);
+    expect(await screen.findAllByText(/published/i)).toHaveLength(4);
   });
 
   it('renders no dependents if there are not any', async () => {

--- a/src/api.js
+++ b/src/api.js
@@ -74,8 +74,10 @@ const endpoints = {
     `/v2/_zot/ext/search?query={Image(image: "${name}"){History {Layer {Size Digest Score} HistoryDescription {Created CreatedBy Author Comment EmptyLayer} }}}`,
   imageListWithCVEFixed: (cveId, repoName) =>
     `/v2/_zot/ext/search?query={ImageListWithCVEFixed(id:"${cveId}", image:"${repoName}") {Tag}}`,
-  dependsOnForImage: (name) => `/v2/_zot/ext/search?query={BaseImageList(image: "${name}"){RepoName}}`,
-  isDependentOnForImage: (name) => `/v2/_zot/ext/search?query={DerivedImageList(image: "${name}"){RepoName}}`,
+  dependsOnForImage: (name) =>
+    `/v2/_zot/ext/search?query={BaseImageList(image: "${name}"){RepoName Tag Description Vendor LastUpdated Platform {Os Arch} IsSigned}}`,
+  isDependentOnForImage: (name) =>
+    `/v2/_zot/ext/search?query={DerivedImageList(image: "${name}"){RepoName Tag Description Vendor LastUpdated Platform {Os Arch} IsSigned}}`,
   globalSearch: ({ searchQuery = '""', pageNumber = 1, pageSize = 15, filter = {} }) => {
     const searchParam = searchQuery !== '' ? `query:"${searchQuery}"` : `query:""`;
     const paginationParam = `requestedPage: {limit:${pageSize} offset:${(pageNumber - 1) * pageSize}}`;

--- a/src/components/DependsOn.jsx
+++ b/src/components/DependsOn.jsx
@@ -4,12 +4,11 @@ import React, { useEffect, useState, useMemo } from 'react';
 import { api, endpoints } from '../api';
 
 // components
-import { Divider, Typography, Card, CardContent } from '@mui/material';
+import { Divider, Typography } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
-import { Link } from 'react-router-dom';
 import { host } from '../host';
-import Monitor from '../assets/Monitor.png';
 import Loading from './Loading';
+import RepoCard from './RepoCard';
 
 const useStyles = makeStyles(() => ({
   card: {
@@ -95,22 +94,22 @@ function DependsOn(props) {
 
   const renderDependencies = () => {
     return images?.length ? (
-      <Card className={classes.card} raised>
-        <CardContent>
-          <Typography className={classes.content}>
-            {images.map((dependence, index) => {
-              return (
-                <Link key={index} className={classes.link} to={`/image/${encodeURIComponent(dependence.RepoName)}`}>
-                  {dependence.RepoName}
-                </Link>
-              );
-            })}
-          </Typography>
-        </CardContent>
-      </Card>
+      images.map((dependence, index) => {
+        return (
+          <RepoCard
+            name={dependence.RepoName}
+            version={dependence.Tag}
+            description={dependence.Description}
+            vendor={dependence.Vendor}
+            platforms={[dependence.Platform]}
+            isSigned={dependence.IsSigned}
+            key={index}
+            lastUpdated={dependence.LastUpdated}
+          />
+        );
+      })
     ) : (
       <div>
-        <img src={Monitor} alt="Monitor" className={classes.monitor}></img>
         <Typography className={classes.none}> Nothing found </Typography>
       </div>
     );
@@ -118,16 +117,6 @@ function DependsOn(props) {
 
   return (
     <div data-testid="depends-on-container">
-      <Typography
-        variant="h4"
-        gutterBottom
-        component="div"
-        align="left"
-        className={classes.title}
-        style={{ color: 'rgba(0, 0, 0, 0.87)', fontSize: '1.5rem', fontWeight: '600', paddingTop: '0.5rem' }}
-      >
-        Depends On
-      </Typography>
       <Divider
         variant="fullWidth"
         sx={{ margin: '5% 0% 5% 0%', background: 'rgba(0, 0, 0, 0.38)', height: '0.00625rem', width: '100%' }}

--- a/src/components/Explore.jsx
+++ b/src/components/Explore.jsx
@@ -109,15 +109,10 @@ function Explore() {
             version={item.latestVersion}
             description={item.description}
             isSigned={item.isSigned}
-            tags={item.tags}
             vendor={item.vendor}
             platforms={item.platforms}
-            size={item.size}
-            licenses={item.licenses}
             key={index}
-            data={item}
             lastUpdated={item.lastUpdated}
-            shown={true}
           />
         );
       })

--- a/src/components/HistoryLayers.jsx
+++ b/src/components/HistoryLayers.jsx
@@ -8,7 +8,6 @@ import { api, endpoints } from '../api';
 import { Card, CardContent, Divider, Grid, Stack, Typography } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import { host } from '../host';
-import Monitor from '../assets/Monitor.png';
 import { isEmpty } from 'lodash';
 import Loading from './Loading';
 
@@ -210,7 +209,6 @@ function HistoryLayers(props) {
         </Card>
       ) : (
         <div>
-          <img src={Monitor} alt="Monitor" className={classes.monitor}></img>
           <Typography className={classes.none}> No Layers </Typography>
         </div>
       )}

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -120,7 +120,6 @@ function Home() {
   //           key={index}
   //           data={item}
   //           lastUpdated={item.lastUpdated}
-  //           shown={true}
   //         />
   //       );
   //     })
@@ -137,15 +136,10 @@ function Home() {
             version={item.latestVersion}
             description={item.description}
             isSigned={item.isSigned}
-            tags={item.tags}
             vendor={item.vendor}
             platforms={item.platforms}
-            size={item.size}
-            licenses={item.licenses}
             key={index}
-            data={item}
             lastUpdated={item.lastUpdated}
-            shown={true}
           />
         );
       })

--- a/src/components/IsDependentOn.jsx
+++ b/src/components/IsDependentOn.jsx
@@ -4,12 +4,11 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { api, endpoints } from '../api';
 
 // components
-import { Divider, Typography, Card, CardContent } from '@mui/material';
+import { Divider, Typography } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
-import { Link } from 'react-router-dom';
 import { host } from '../host';
-import Monitor from '../assets/Monitor.png';
 import Loading from './Loading';
+import RepoCard from './RepoCard';
 
 const useStyles = makeStyles(() => ({
   card: {
@@ -95,22 +94,22 @@ function IsDependentOn(props) {
 
   const renderDependents = () => {
     return images?.length ? (
-      <Card className={classes.card} raised>
-        <CardContent>
-          <Typography className={classes.content}>
-            {images.map((dependence, index) => {
-              return (
-                <Link key={index} to={`/image/${encodeURIComponent(dependence.RepoName)}`} className={classes.link}>
-                  {dependence.RepoName}
-                </Link>
-              );
-            })}
-          </Typography>
-        </CardContent>
-      </Card>
+      images.map((dependence, index) => {
+        return (
+          <RepoCard
+            name={dependence.RepoName}
+            version={dependence.Tag}
+            description={dependence.Description}
+            vendor={dependence.Vendor}
+            isSigned={dependence.IsSigned}
+            platforms={[dependence.Platform]}
+            key={index}
+            lastUpdated={dependence.LastUpdated}
+          />
+        );
+      })
     ) : (
       <div>
-        <img src={Monitor} alt="Monitor" className={classes.monitor}></img>
         <Typography className={classes.none}> Nothing found </Typography>
       </div>
     );
@@ -118,16 +117,6 @@ function IsDependentOn(props) {
 
   return (
     <div>
-      <Typography
-        variant="h4"
-        gutterBottom
-        component="div"
-        align="left"
-        className={classes.title}
-        style={{ color: 'rgba(0, 0, 0, 0.87)', fontSize: '1.5rem', fontWeight: '600', paddingTop: '0.5rem' }}
-      >
-        Is Dependent On
-      </Typography>
       <Divider
         variant="fullWidth"
         sx={{ margin: '5% 0% 5% 0%', background: 'rgba(0, 0, 0, 0.38)', height: '0.00625rem', width: '100%' }}

--- a/src/components/RepoDetailsMetadata.jsx
+++ b/src/components/RepoDetailsMetadata.jsx
@@ -61,7 +61,7 @@ function RepoDetailsMetadata(props) {
               Total downloads
             </Typography>
             <Typography variant="body1" align="left" className={classes.metadataBody}>
-              {totalDownloads || `not available`}
+              {!isNaN(totalDownloads) ? totalDownloads : `not available`}
             </Typography>
           </CardContent>
         </Card>

--- a/src/components/VulnerabilitiesDetails.jsx
+++ b/src/components/VulnerabilitiesDetails.jsx
@@ -10,7 +10,6 @@ import makeStyles from '@mui/styles/makeStyles';
 import { host } from '../host';
 import PestControlOutlinedIcon from '@mui/icons-material/PestControlOutlined';
 import PestControlIcon from '@mui/icons-material/PestControl';
-import Monitor from '../assets/Monitor.png';
 import { isEmpty } from 'lodash';
 import { Link } from 'react-router-dom';
 import Loading from './Loading';
@@ -291,7 +290,6 @@ function VulnerabilitiesDetails(props) {
     } else {
       return (
         <div>
-          <img src={Monitor} alt="Monitor" className={classes.monitor}></img>
           <Typography className={classes.none}> No Vulnerabilities </Typography>{' '}
         </div>
       );


### PR DESCRIPTION
Signed-off-by: Raul Kele <raulkeleblk@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Closes #124 
Closes #129 

**What does this PR do / Why do we need it**:
Updated used by/uses tabs to use cards and removed unnecessary parts of ui

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
- Removed unnecessary text in uses and used by tabs on image page
- Changed display of used used by images to cards instead of text
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
