### PR TITLE
fix: Added logic to get fixed tags only on user action

### DIFF
--- a/src/__tests__/TagPage/VulnerabilitiesDetails.test.js
+++ b/src/__tests__/TagPage/VulnerabilitiesDetails.test.js
@@ -456,7 +456,7 @@ describe('Vulnerabilties page', () => {
     jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: { data: mockCVEList } });
     render(<StateVulnerabilitiesWrapper />);
     await waitFor(() => expect(screen.getAllByText('Vulnerabilities')).toHaveLength(1));
-    await waitFor(() => expect(screen.getAllByText(/Fixed in/i)).toHaveLength(20));
+    await waitFor(() => expect(screen.getAllByText(/see fix tags/i)).toHaveLength(20));
   });
 
   it('renders no vulnerabilities if there are not any', async () => {
@@ -497,6 +497,7 @@ describe('Vulnerabilties page', () => {
       .mockResolvedValue({ status: 200, data: { data: mockCVEFixed } });
     render(<StateVulnerabilitiesWrapper />);
     await waitFor(() => expect(screen.getAllByText('Vulnerabilities')).toHaveLength(1));
-    await waitFor(() => expect(screen.getAllByText('1.0.16')).toHaveLength(20));
+    fireEvent.click(screen.getAllByText(/see fix tags/i)[0]);
+    await waitFor(() => expect(screen.getByText('1.0.16')).toBeInTheDocument());
   });
 });

--- a/src/components/VulnerabilitiesDetails.jsx
+++ b/src/components/VulnerabilitiesDetails.jsx
@@ -165,11 +165,15 @@ const vulnerabilityCheck = (status) => {
 function VulnerabilitiyCard(props) {
   const classes = useStyles();
   const { cve, name } = props;
-  const [open, setOpen] = useState(false);
+  const [openDesc, setOpenDesc] = useState(false);
+  const [openFixed, setOpenFixed] = useState(false);
   const [loadingFixed, setLoadingFixed] = useState(true);
   const [fixedInfo, setFixedInfo] = useState([]);
 
   useEffect(() => {
+    if (!openFixed || !isEmpty(fixedInfo)) {
+      return;
+    }
     setLoadingFixed(true);
     api
       .get(`${host()}${endpoints.imageListWithCVEFixed(cve.Id, name)}`)
@@ -183,7 +187,7 @@ function VulnerabilitiyCard(props) {
       .catch((e) => {
         console.error(e);
       });
-  }, []);
+  }, [openFixed]);
 
   const renderFixedVer = () => {
     if (!isEmpty(fixedInfo)) {
@@ -215,15 +219,6 @@ function VulnerabilitiyCard(props) {
             {cve.Title}
           </Typography>
         </Stack>
-        <Stack sx={{ flexDirection: 'row' }}>
-          <Typography variant="body1" align="left" className={classes.title}>
-            Fixed In:{' '}
-          </Typography>
-          <Typography variant="body1" align="left" className={classes.values} noWrap>
-            {' '}
-            {loadingFixed ? 'Loading...' : renderFixedVer()}
-          </Typography>
-        </Stack>
         <Typography
           sx={{
             color: '#1479FF',
@@ -232,11 +227,31 @@ function VulnerabilitiyCard(props) {
             fontWeight: '600',
             cursor: 'pointer'
           }}
-          onClick={() => setOpen(!open)}
+          onClick={() => setOpenFixed(!openFixed)}
         >
-          {!open ? 'See description' : 'Hide description'}
+          {!openFixed ? 'See fix tags' : 'Hide fix tags'}
         </Typography>
-        <Collapse in={open} timeout="auto" unmountOnExit>
+        <Collapse in={openFixed} timeout="auto" unmountOnExit>
+          <Box>
+            <Typography variant="body2" align="left" sx={{ color: '#0F2139', fontSize: '1rem' }}>
+              {' '}
+              {loadingFixed ? 'Loading...' : renderFixedVer()}{' '}
+            </Typography>
+          </Box>
+        </Collapse>
+        <Typography
+          sx={{
+            color: '#1479FF',
+            paddingTop: '1rem',
+            fontSize: '0.8125rem',
+            fontWeight: '600',
+            cursor: 'pointer'
+          }}
+          onClick={() => setOpenDesc(!openDesc)}
+        >
+          {!openDesc ? 'See description' : 'Hide description'}
+        </Typography>
+        <Collapse in={openDesc} timeout="auto" unmountOnExit>
           <Box>
             <Typography variant="body2" align="left" sx={{ color: '#0F2139', fontSize: '1rem' }}>
               {' '}


### PR DESCRIPTION
Signed-off-by: Raul Kele <raulkeleblk@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Closes #145 

**What does this PR do / Why do we need it**:
Added user interaction in order to fetch and display tags with cve fixed

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
- Updated display of fixed tags on CVE cards
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
