### PR TITLE
patch: Changed display values of filters, added tooltip on hover

### DIFF
--- a/src/components/FilterCard.jsx
+++ b/src/components/FilterCard.jsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, Checkbox, FormControlLabel, Stack, Typography } from '@mui/material';
+import { Card, CardContent, Checkbox, FormControlLabel, Stack, Tooltip, Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import React from 'react';
 
@@ -44,15 +44,16 @@ function FilterCard(props) {
     const filterRows = filters;
     return filterRows.map((filter, index) => {
       return (
-        <FormControlLabel
-          key={index}
-          componentsProps={{ typography: { variant: 'body2' } }}
-          control={<Checkbox />}
-          label={filter.label}
-          id={title}
-          // checked={filter.label === selectedFilter}
-          onChange={() => handleFilterClicked(event, filter.label, filter.value)}
-        />
+        <Tooltip key={index} title={filter.tooltip ?? filter.label} placement="right">
+          <FormControlLabel
+            componentsProps={{ typography: { variant: 'body2' } }}
+            control={<Checkbox />}
+            label={filter.label}
+            id={title}
+            // checked={filter.label === selectedFilter}
+            onChange={() => handleFilterClicked(event, filter.label, filter.value)}
+          />
+        </Tooltip>
       );
     });
   };

--- a/src/utilities/filterConstants.js
+++ b/src/utilities/filterConstants.js
@@ -19,32 +19,39 @@ const imageFilters = [
 
 const archFilters = [
   {
-    label: 'ARM',
-    value: 'arm'
+    label: 'arm',
+    value: 'arm',
+    tooltip: '32-bit ARM'
   },
   {
-    label: 'ARM 64',
-    value: 'arm64'
+    label: 'arm64',
+    value: 'arm64',
+    tooltip: '64-bit ARM'
   },
   {
-    label: 'IBM POWER',
-    value: 'ppc64'
+    label: 'ppc64',
+    value: 'ppc64',
+    tooltip: 'PowerPC 64-bit, big-endian'
   },
   {
-    label: 'IBM Z',
-    value: 's390x'
+    label: 's390x',
+    value: 's390x',
+    tooltip: 'IBM System z 64-bit, big-endian'
   },
   {
-    label: 'PowerPC 64 LE',
-    value: 'ppc64le'
+    label: 'ppc64le',
+    value: 'ppc64le',
+    tooltip: 'PowerPC 64-bit, little-endian'
   },
   {
-    label: 'x86',
-    value: '386'
+    label: '386',
+    value: '386',
+    tooltip: '32-bit x86'
   },
   {
-    label: 'x86-64',
-    value: 'amd64'
+    label: 'amd64',
+    value: 'amd64',
+    tooltip: '64-bit x86'
   }
 ];
 


### PR DESCRIPTION
Signed-off-by: Raul Kele <raulkeleblk@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Closes #112 

**What does this PR do / Why do we need it**:
Changed display labels of filters on Explore page to match Architectures described in the GOARCH document, with the detailed version displayed on hover

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
- Updated explore page filters labels
- Added tooltip with more details on hover
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
