### PR TITLE
patch: Added arrow to digest dropdown

### DIFF
--- a/src/__tests__/RepoPage/Tags.test.js
+++ b/src/__tests__/RepoPage/Tags.test.js
@@ -24,13 +24,15 @@ const mockedTagsData = [
 ];
 
 describe('Tags component', () => {
-  it('should open and close details dropdown for tags', () => {
+  it('should open and close details dropdown for tags', async () => {
     render(<Tags tags={mockedTagsData} />);
-    const openBtn = screen.getByText(/see digest/i);
+    const openBtn = screen.getByText(/digest/i);
     fireEvent.click(openBtn);
-    expect(screen.queryByText(/see digest/i)).not.toBeInTheDocument();
-    expect(screen.getByText(/hide digest/i)).toBeInTheDocument();
+    expect(screen.getByText(/OS\/ARCH/i)).toBeInTheDocument();
+    fireEvent.click(openBtn);
+    await waitFor(() => expect(screen.queryByText(/OS\/ARCH/i)).not.toBeInTheDocument());
   });
+
   it('should navigate to tag page details when tag is clicked', async () => {
     render(<Tags tags={mockedTagsData} />);
     const tagLink = await screen.findByText('latest');

--- a/src/components/TagCard.jsx
+++ b/src/components/TagCard.jsx
@@ -19,6 +19,7 @@ import {
 import { Markdown } from 'utilities/MarkdowntojsxWrapper';
 import transform from 'utilities/transform';
 import { DateTime } from 'luxon';
+import { KeyboardArrowDown, KeyboardArrowRight } from '@mui/icons-material';
 
 const useStyles = makeStyles(() => ({
   tagCard: {
@@ -57,6 +58,18 @@ const useStyles = makeStyles(() => ({
   },
   clickCursor: {
     cursor: 'pointer'
+  },
+  dropdown: {
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  dropdownText: {
+    color: '#1479FF',
+    paddingTop: '1rem',
+    fontSize: '1rem',
+    fontWeight: '600',
+    cursor: 'pointer',
+    textAlign: 'center'
   }
 }));
 
@@ -107,19 +120,24 @@ export default function TagCard(props) {
             </Typography>
           </Tooltip>
         </Stack>
-
-        <Typography
-          sx={{
-            color: '#1479FF',
-            paddingTop: '1rem',
-            fontSize: '0.8125rem',
-            fontWeight: '600',
-            cursor: 'pointer'
-          }}
-          onClick={() => setOpen(!open)}
-        >
-          {!open ? 'See digest' : 'Hide digest'}
-        </Typography>
+        <Stack direction="row" onClick={() => setOpen(!open)}>
+          {!open ? (
+            <KeyboardArrowRight className={classes.dropdownText} />
+          ) : (
+            <KeyboardArrowDown className={classes.dropdownText} />
+          )}
+          <Typography
+            sx={{
+              color: '#1479FF',
+              paddingTop: '1rem',
+              fontSize: '0.8125rem',
+              fontWeight: '600',
+              cursor: 'pointer'
+            }}
+          >
+            DIGEST
+          </Typography>
+        </Stack>
         <Collapse in={open} timeout="auto" unmountOnExit>
           <Box>
             <Table size="small" padding="none" sx={{ [`& .${tableCellClasses.root}`]: { borderBottom: 'none' } }}>
@@ -145,7 +163,7 @@ export default function TagCard(props) {
                   className={classes.clickCursor}
                 >
                   <TableCell style={{ color: '#696969' }}>
-                    <Tooltip title={digest || ''} placement="right">
+                    <Tooltip title={digest || ''} placement="top">
                       <Typography variant="body1">{digest?.substr(0, 12)}</Typography>
                     </Tooltip>
                   </TableCell>

--- a/src/utilities/MarkdowntojsxWrapper.jsx
+++ b/src/utilities/MarkdowntojsxWrapper.jsx
@@ -4,7 +4,10 @@ import Markdown from 'markdown-to-jsx';
 const MarkdownWrapper = (props) => {
   const { children, options } = props;
   return (
-    <Markdown {...props} options={{ ...options, overrides: { a: { props: { target: '_blank' } } } }}>
+    <Markdown
+      {...props}
+      options={{ ...options, disableParsingRawHTML: true, overrides: { a: { props: { target: '_blank' } } } }}
+    >
       {children}
     </Markdown>
   );


### PR DESCRIPTION
Also updated md parser config

Signed-off-by: Raul Kele <raulkeleblk@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Closes #166 

**What does this PR do / Why do we need it**:
Updated display of digest dropdown on TagCard

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
- Updated display of digest dropdown in tag card to match vulnerability card dropdowns
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
