### PR TITLE
fix: hide unknown vulnerability

### DIFF
--- a/src/__tests__/Explore/Explore.test.js
+++ b/src/__tests__/Explore/Explore.test.js
@@ -167,7 +167,7 @@ describe('Explore component', () => {
     expect(await screen.findAllByTestId('critical-vulnerability-icon')).toHaveLength(1);
     expect(await screen.findAllByTestId('none-vulnerability-icon')).toHaveLength(1);
     expect(await screen.findAllByTestId('medium-vulnerability-icon')).toHaveLength(1);
-    expect(await screen.findAllByTestId('unknown-vulnerability-icon')).toHaveLength(1);
+    // expect(await screen.findAllByTestId('unknown-vulnerability-icon')).toHaveLength(1);
   });
 
   it("should log an error when data can't be fetched", async () => {

--- a/src/__tests__/RepoPage/Repo.test.js
+++ b/src/__tests__/RepoPage/Repo.test.js
@@ -66,27 +66,27 @@ const mockRepoDetailsNone = {
   }
 };
 
-const mockRepoDetailsUnknown = {
-  ExpandedRepoInfo: {
-    Images: [
-      {
-        Digest: '2aa7ff5ca352d4d25fc6548f9930a436aacd64d56b1bd1f9ff4423711b9c8718',
-        Tag: 'latest'
-      }
-    ],
-    Summary: {
-      Name: 'test1',
-      NewestImage: {
-        RepoName: 'mongo',
-        IsSigned: true,
-        Vulnerabilities: {
-          MaxSeverity: 'UNKNOWN',
-          Count: 15
-        }
-      }
-    }
-  }
-};
+// const mockRepoDetailsUnknown = {
+//   ExpandedRepoInfo: {
+//     Images: [
+//       {
+//         Digest: '2aa7ff5ca352d4d25fc6548f9930a436aacd64d56b1bd1f9ff4423711b9c8718',
+//         Tag: 'latest'
+//       }
+//     ],
+//     Summary: {
+//       Name: 'test1',
+//       NewestImage: {
+//         RepoName: 'mongo',
+//         IsSigned: true,
+//         Vulnerabilities: {
+//           MaxSeverity: 'UNKNOWN',
+//           Count: 15
+//         }
+//       }
+//     }
+//   }
+// };
 
 const mockRepoDetailsLow = {
   ExpandedRepoInfo: {
@@ -177,9 +177,9 @@ describe('Repo details component', () => {
     render(<RepoDetails />);
     expect(await screen.findAllByTestId('none-vulnerability-icon')).toHaveLength(1);
     // @ts-ignore
-    jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: { data: mockRepoDetailsUnknown } });
-    render(<RepoDetails />);
-    expect(await screen.findAllByTestId('unknown-vulnerability-icon')).toHaveLength(1);
+    // jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: { data: mockRepoDetailsUnknown } });
+    // render(<RepoDetails />);
+    // expect(await screen.findAllByTestId('unknown-vulnerability-icon')).toHaveLength(1);
     // @ts-ignore
     jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: { data: mockRepoDetailsLow } });
     render(<RepoDetails />);

--- a/src/__tests__/TagPage/TagDetails.test.js
+++ b/src/__tests__/TagPage/TagDetails.test.js
@@ -81,25 +81,25 @@ const mockImageNone = {
   }
 };
 
-const mockImageUnknown = {
-  Image: {
-    RepoName: 'centos',
-    Tag: '8',
-    Digest: 'sha256:63a795ca90aa6e7cca60941e826810a4cd0a2e73ea02bf458241df2a5c973e29',
-    LastUpdated: '2020-12-08T00:22:52.526672082Z',
-    Size: '75183423',
-    ConfigDigest: 'sha256:8dd57e171a61368ffcfde38045ddb6ed74a32950c271c1da93eaddfb66a77e78',
-    Platform: {
-      Os: 'linux',
-      Arch: 'amd64'
-    },
-    Vulnerabilities: {
-      MaxSeverity: 'UNKNOWN',
-      Count: 10
-    },
-    Vendor: 'CentOS'
-  }
-};
+// const mockImageUnknown = {
+//   Image: {
+//     RepoName: 'centos',
+//     Tag: '8',
+//     Digest: 'sha256:63a795ca90aa6e7cca60941e826810a4cd0a2e73ea02bf458241df2a5c973e29',
+//     LastUpdated: '2020-12-08T00:22:52.526672082Z',
+//     Size: '75183423',
+//     ConfigDigest: 'sha256:8dd57e171a61368ffcfde38045ddb6ed74a32950c271c1da93eaddfb66a77e78',
+//     Platform: {
+//       Os: 'linux',
+//       Arch: 'amd64'
+//     },
+//     Vulnerabilities: {
+//       MaxSeverity: 'UNKNOWN',
+//       Count: 10
+//     },
+//     Vendor: 'CentOS'
+//   }
+// };
 
 const mockImageLow = {
   Image: {
@@ -226,9 +226,9 @@ describe('Tags details', () => {
     render(<TagDetails />);
     expect(await screen.findAllByTestId('none-vulnerability-icon')).toHaveLength(1);
     // @ts-ignore
-    jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: { data: mockImageUnknown } });
-    render(<TagDetails />);
-    expect(await screen.findAllByTestId('unknown-vulnerability-icon')).toHaveLength(1);
+    // jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: { data: mockImageUnknown } });
+    // render(<TagDetails />);
+    // expect(await screen.findAllByTestId('unknown-vulnerability-icon')).toHaveLength(1);
     // @ts-ignore
     jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: { data: mockImageLow } });
     render(<TagDetails />);

--- a/src/utilities/vulnerabilityAndSignatureCheck.js
+++ b/src/utilities/vulnerabilityAndSignatureCheck.js
@@ -1,13 +1,11 @@
 import React from 'react';
 import {
   NoneVulnerabilityIcon,
-  UnknownVulnerabilityIcon,
   LowVulnerabilityIcon,
   MediumVulnerabilityIcon,
   HighVulnerabilityIcon,
   CriticalVulnerabilityIcon,
   NoneVulnerabilityChip,
-  UnknownVulnerabilityChip,
   LowVulnerabilityChip,
   MediumVulnerabilityChip,
   HighVulnerabilityChip,
@@ -41,7 +39,7 @@ const VulnerabilityIconCheck = ({ vulnerabilitySeverity }) => {
       result = <CriticalVulnerabilityIcon vulnerabilityStringTitle={vulnerabilityStringTitle} />;
       break;
     default:
-      result = <UnknownVulnerabilityIcon vulnerabilityStringTitle={vulnerabilityStringTitle} />;
+      result = <></>;
   }
   return result;
 };
@@ -65,7 +63,7 @@ const VulnerabilityChipCheck = ({ vulnerabilitySeverity }) => {
       result = <CriticalVulnerabilityChip />;
       break;
     default:
-      result = <UnknownVulnerabilityChip />;
+      result = <></>;
   }
   return result;
 };


### PR DESCRIPTION
Signed-off-by: Raul Kele <raulkeleblk@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
cleanup
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Closes #195 


**What does this PR do / Why do we need it**:
Temporary fix for #195, the larger logic of which chip to hide and show when the backend returns a "UNKNOWN" severity still needs follow-up

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
