### PR TITLE
fix: Fixed empty query string if user types fast

### DIFF
--- a/src/components/SearchSuggestion.jsx
+++ b/src/components/SearchSuggestion.jsx
@@ -114,8 +114,9 @@ function SearchSuggestion() {
 
   const handleSearch = (event) => {
     const { key, type } = event;
+    const { value } = event.target;
     if (key === 'Enter' || type === 'click') {
-      navigate({ pathname: `/explore`, search: createSearchParams({ search: searchQuery }).toString() });
+      navigate({ pathname: `/explore`, search: createSearchParams({ search: value || '' }).toString() });
     }
   };
 
@@ -166,12 +167,15 @@ function SearchSuggestion() {
   };
 
   const handleSeachChange = (event) => {
-    const value = event.inputValue;
+    const value = event?.inputValue;
     setSearchQuery(value);
     setIsFailedSearch(false);
+    setIsLoading(true);
     setSuggestionData([]);
+  };
+
+  const searchCall = (value) => {
     if (value !== '') {
-      setIsLoading(true);
       // if search term inclused the ':' character, search for images, if not, search repos
       if (value?.includes(':')) {
         imageSearch(value);
@@ -182,8 +186,12 @@ function SearchSuggestion() {
   };
 
   const debounceSuggestions = useMemo(() => {
-    return debounce(handleSeachChange, 300);
+    return debounce(searchCall, 300);
   }, []);
+
+  useEffect(() => {
+    debounceSuggestions(searchQuery);
+  }, [searchQuery]);
 
   useEffect(() => {
     return () => {
@@ -204,7 +212,7 @@ function SearchSuggestion() {
     // closeMenu
   } = useCombobox({
     items: suggestionData,
-    onInputValueChange: debounceSuggestions,
+    onInputValueChange: handleSeachChange,
     onSelectedItemChange: handleSuggestionSelected,
     itemToString: (item) => item.name ?? ''
   });
@@ -259,7 +267,7 @@ function SearchSuggestion() {
       </Stack>
       <List
         {...getMenuProps()}
-        className={isOpen && !isLoading ? classes.resultsWrapper : classes.resultsWrapperHidden}
+        className={isOpen && !isLoading && !isFailedSearch ? classes.resultsWrapper : classes.resultsWrapperHidden}
       >
         {isOpen && suggestionData?.length > 0 && renderSuggestions()}
         {isOpen && isEmpty(searchQuery) && (


### PR DESCRIPTION
Signed-off-by: Raul Kele <raulkeleblk@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Closes #197 

**What does this PR do / Why do we need it**:
Changed loading/failed/open state logic in searchSuggestion component to fix issues stemming from user actions being too fast

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
