### PR TITLE
feat: implemented support for preselected sort order and filters

### DIFF
--- a/src/__tests__/Explore/Explore.test.js
+++ b/src/__tests__/Explore/Explore.test.js
@@ -3,7 +3,9 @@ import userEvent from '@testing-library/user-event';
 import { api } from 'api';
 import Explore from 'components/Explore';
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { createSearchParams, MemoryRouter } from 'react-router-dom';
+import filterConstants from 'utilities/filterConstants.js';
+import { sortByCriteria } from 'utilities/sortCriteria.js';
 
 // router mock
 const mockedUsedNavigate = jest.fn();
@@ -15,7 +17,7 @@ jest.mock('react-router-dom', () => ({
 const StateExploreWrapper = (props) => {
   const queryString = props.search || '';
   return (
-    <MemoryRouter initialEntries={[queryString]}>
+    <MemoryRouter initialEntries={[`/explore?${queryString.toString()}`]}>
       <Explore />
     </MemoryRouter>
   );
@@ -195,5 +197,21 @@ describe('Explore component', () => {
     const newOption = await screen.findByText('Alphabetical');
     userEvent.click(newOption);
     expect(await screen.findByText('Alphabetical')).toBeInTheDocument();
+  });
+
+  it('should get preselected filters and sorting order from query params', async () => {
+    jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: { data: mockImageList } });
+    render(
+      <StateExploreWrapper
+        search={createSearchParams({
+          filter: filterConstants.osFilters[0].value,
+          sortby: sortByCriteria.downloads.value
+        })}
+      />
+    );
+    const sortyBySelect = await screen.findByText(sortByCriteria.downloads.label);
+    expect(sortyBySelect).toBeInTheDocument();
+    const filterCheckboxes = await screen.findAllByRole('checkbox');
+    expect(filterCheckboxes[0]).toBeChecked();
   });
 });

--- a/src/__tests__/Explore/FilterCard.test.js
+++ b/src/__tests__/Explore/FilterCard.test.js
@@ -1,20 +1,23 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import FilterCard from 'components/FilterCard';
-import React from 'react';
+import React, { useState } from 'react';
 import filterConstants from 'utilities/filterConstants';
 
 const StateFilterCardWrapper = () => {
-  return <FilterCard title="Products" filters={filterConstants.osFilters} updateFilters={() => {}} filterValue={[]} />;
+  const [filters, setFilters] = useState([]);
+  return (
+    <FilterCard title="Products" filters={filterConstants.osFilters} updateFilters={setFilters} filterValue={filters} />
+  );
 };
 
 describe('Filters components', () => {
-  it('renders the filters cards', () => {
+  it('renders the filters cards', async () => {
     render(<StateFilterCardWrapper />);
     expect(screen.getAllByRole('checkbox')).toHaveLength(2);
 
     const checkbox = screen.getAllByRole('checkbox');
     expect(checkbox[0]).not.toBeChecked();
     fireEvent.click(checkbox[0]);
-    expect(checkbox[0]).toBeChecked();
+    await waitFor(() => expect(checkbox[0]).toBeChecked());
   });
 });

--- a/src/__tests__/HomePage/Home.test.js
+++ b/src/__tests__/HomePage/Home.test.js
@@ -1,7 +1,9 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { api } from 'api';
 import Home from 'components/Home';
 import React from 'react';
+import { createSearchParams } from 'react-router-dom';
+import { sortByCriteria } from 'utilities/sortCriteria';
 
 // useNavigate mock
 const mockedUsedNavigate = jest.fn();
@@ -157,5 +159,22 @@ describe('Home component', () => {
     const error = jest.spyOn(console, 'error').mockImplementation(() => {});
     render(<Home />);
     await waitFor(() => expect(error).toBeCalledTimes(1));
+  });
+
+  it('should redirect to explore page when clicking view all popular', async () => {
+    jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: { data: mockImageList } });
+    render(<Home />);
+    const viewAllButtons = await screen.findAllByText(/view all/i);
+    expect(viewAllButtons).toHaveLength(2);
+    fireEvent.click(viewAllButtons[0]);
+    expect(mockedUsedNavigate).toHaveBeenCalledWith({
+      pathname: `/explore`,
+      search: createSearchParams({ sortby: sortByCriteria.downloads.value }).toString()
+    });
+    fireEvent.click(viewAllButtons[1]);
+    expect(mockedUsedNavigate).toHaveBeenCalledWith({
+      pathname: `/explore`,
+      search: createSearchParams({ sortby: sortByCriteria.updateTime.value }).toString()
+    });
   });
 });

--- a/src/__tests__/Shared/RepoCard.test.js
+++ b/src/__tests__/Shared/RepoCard.test.js
@@ -1,7 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import RepoCard from 'components/RepoCard';
+import { createSearchParams } from 'react-router-dom';
 
 // usenavigate mock
 const mockedUsedNavigate = jest.fn();
@@ -19,7 +20,8 @@ const mockImage = {
   licenses: '',
   vendor: '',
   size: '585',
-  tags: ''
+  tags: '',
+  platforms: [{ Os: 'linux', Arch: 'amd64' }]
 };
 
 afterEach(() => {
@@ -43,5 +45,25 @@ describe('Repo card component', () => {
     expect(cardTitle).toBeInTheDocument();
     userEvent.click(cardTitle);
     expect(mockedUsedNavigate).toBeCalledWith(`/image/${mockImage.name}`);
+  });
+
+  it('navigates to explore page when platform chip is clicked', async () => {
+    render(
+      <RepoCard
+        name={mockImage.name}
+        version={mockImage.latestVersion}
+        description={mockImage.description}
+        vendor={mockImage.vendor}
+        key={1}
+        lastUpdated={mockImage.lastUpdated}
+        platforms={mockImage.platforms}
+      />
+    );
+    const osChip = await screen.findByText(/linux/i);
+    fireEvent.click(osChip);
+    expect(mockedUsedNavigate).toHaveBeenCalledWith({
+      pathname: '/explore',
+      search: createSearchParams({ filter: 'linux' }).toString()
+    });
   });
 });

--- a/src/api.js
+++ b/src/api.js
@@ -85,7 +85,7 @@ const endpoints = {
     sortBy = sortByCriteria.relevance.value,
     filter = {}
   }) => {
-    const searchParam = searchQuery !== '' ? `query:"${searchQuery}"` : `query:""`;
+    const searchParam = !isEmpty(searchQuery) ? `query:"${searchQuery}"` : `query:""`;
     const paginationParam = `requestedPage: {limit:${pageSize} offset:${
       (pageNumber - 1) * pageSize
     } sortBy: ${sortBy}}`;

--- a/src/components/Explore.jsx
+++ b/src/components/Explore.jsx
@@ -84,6 +84,27 @@ function Explore() {
     return filter;
   };
 
+  const deconstructFilterQuery = () => {
+    const preselectedFilter = queryParams.get('filter');
+    if (!isEmpty(preselectedFilter)) {
+      if (filterConstants.osFilters.map((f) => f.value).includes(preselectedFilter)) {
+        setOSFilters([...osFilters, preselectedFilter]);
+      } else if (filterConstants.archFilters.map((f) => f.value).includes(preselectedFilter)) {
+        setArchFilters([...archFilters, preselectedFilter]);
+      }
+      queryParams.delete('filter');
+    }
+    const preselectedSortOrder = queryParams.get('sortby');
+    if (!isEmpty(preselectedSortOrder)) {
+      const debug = Object.values(sortByCriteria);
+      const sortFilterValue = debug.find((sbc) => sbc.value === preselectedSortOrder);
+      if (sortFilterValue) {
+        setSortFilter(sortFilterValue.value);
+      }
+      queryParams.delete('sortby');
+    }
+  };
+
   const getPaginatedResults = () => {
     setIsLoading(true);
     api
@@ -138,6 +159,11 @@ function Explore() {
   useEffect(() => {
     resetPagination();
   }, [search, queryParams, imageFilters, osFilters, archFilters, sortFilter]);
+
+  // on component mount, check query params for preselected filters
+  useEffect(() => {
+    deconstructFilterQuery();
+  }, []);
 
   const handleSortChange = (event) => {
     setSortFilter(event.target.value);

--- a/src/components/FilterCard.jsx
+++ b/src/components/FilterCard.jsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, Checkbox, FormControlLabel, Stack, Tooltip, Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
+import { isBoolean, isArray } from 'lodash';
 import React from 'react';
 
 const useStyles = makeStyles(() => ({
@@ -22,7 +23,7 @@ function FilterCard(props) {
 
   const handleFilterClicked = (event, changedFilterLabel, changedFilterValue) => {
     const { checked } = event.target;
-
+    // since checkboxes are controlled, we first have to manually perform the checkbox checked update
     if (checked) {
       if (filters[0]?.type === 'boolean') {
         updateFilters(checked);
@@ -40,6 +41,14 @@ function FilterCard(props) {
     }
   };
 
+  const getCheckboxStatus = (label) => {
+    if (isArray(filterValue)) {
+      return filterValue?.includes(label);
+    } else if (isBoolean(filterValue)) {
+      return filterValue;
+    }
+  };
+
   const getFilterRows = () => {
     const filterRows = filters;
     return filterRows.map((filter, index) => {
@@ -50,7 +59,7 @@ function FilterCard(props) {
             control={<Checkbox />}
             label={filter.label}
             id={title}
-            // checked={filter.label === selectedFilter}
+            checked={getCheckboxStatus(filter.label)}
             onChange={() => handleFilterClicked(event, filter.label, filter.value)}
           />
         </Tooltip>

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -6,6 +6,8 @@ import React, { useEffect, useMemo, useState } from 'react';
 import RepoCard from './RepoCard';
 import { mapToRepo } from 'utilities/objectModels';
 import Loading from './Loading';
+import { useNavigate, createSearchParams } from 'react-router-dom';
+import { sortByCriteria } from 'utilities/sortCriteria';
 
 const useStyles = makeStyles(() => ({
   gridWrapper: {
@@ -57,12 +59,19 @@ const useStyles = makeStyles(() => ({
     lineHeight: '150%',
     letterSpacing: '0.009375rem',
     width: '65%'
+  },
+  viewAll: {
+    color: '#00000099',
+    cursor: 'pointer',
+    textAlign: 'right',
+    width: '100%'
   }
 }));
 
 function Home() {
   const [isLoading, setIsLoading] = useState(true);
   const [homeData, setHomeData] = useState([]);
+  const navigate = useNavigate();
   const abortController = useMemo(() => new AbortController(), []);
   const classes = useStyles();
 
@@ -88,6 +97,10 @@ function Home() {
       abortController.abort();
     };
   }, []);
+
+  const handleClickViewAll = (target) => {
+    navigate({ pathname: `/explore`, search: createSearchParams({ sortby: target }).toString() });
+  };
 
   const renderMostPopular = () => {
     return (
@@ -180,15 +193,31 @@ function Home() {
               </Typography>
             </Stack>
           </Grid>
+          {/* currently most popular will be by downloads until stars are implemented */}
+          <Typography
+            variant="body2"
+            className={classes.viewAll}
+            onClick={() => handleClickViewAll(sortByCriteria.downloads.value)}
+          >
+            View all
+          </Typography>
           {renderMostPopular()}
           {/* <Typography variant="h4" align="left" className={classes.sectionTitle}>
         Bookmarks
       </Typography>
       {renderBookmarks()} */}
-          <Stack></Stack>
-          <Typography variant="h4" align="left" className={classes.sectionTitle}>
-            Recently updated images
-          </Typography>
+          <Stack justifyContent="space-between" alignItems="end" direction="row" sx={{ width: '100%' }}>
+            <Typography variant="h4" align="left" className={classes.sectionTitle}>
+              Recently updated images
+            </Typography>
+            <Typography
+              variant="body2"
+              className={classes.viewAll}
+              onClick={() => handleClickViewAll(sortByCriteria.updateTime.value)}
+            >
+              View all
+            </Typography>
+          </Stack>
           {renderRecentlyUpdated()}
         </Stack>
       )}

--- a/src/components/RepoCard.jsx
+++ b/src/components/RepoCard.jsx
@@ -1,6 +1,6 @@
 // react global
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, createSearchParams } from 'react-router-dom';
 
 // utility
 import { DateTime } from 'luxon';
@@ -111,14 +111,21 @@ function RepoCard(props) {
     navigate(`/image/${encodeURIComponent(name)}`);
   };
 
+  const handlePlatformChipClick = (event) => {
+    const { textContent } = event.target;
+    event.stopPropagation();
+    event.preventDefault();
+    navigate({ pathname: `/explore`, search: createSearchParams({ filter: textContent }).toString() });
+  };
+
   const platformChips = () => {
-    // if platforms not received, mock data
     const platformsOsArch = platforms || [];
     return platformsOsArch.map((platform, index) => (
       <Stack key={`stack${platform?.Os}${platform?.Arch}`} alignItems="center" direction="row" spacing={2}>
         <Chip
           key={`${name}${platform?.Os}${index}`}
           label={platform?.Os}
+          onClick={handlePlatformChipClick}
           sx={{
             backgroundColor: '#E0E5EB',
             color: '#52637A',
@@ -128,6 +135,7 @@ function RepoCard(props) {
         <Chip
           key={`${name}${platform?.Arch}${index}`}
           label={platform?.Arch}
+          onClick={handlePlatformChipClick}
           sx={{
             backgroundColor: '#E0E5EB',
             color: '#52637A',
@@ -152,7 +160,7 @@ function RepoCard(props) {
   return (
     <Card variant="outlined" className={classes.card}>
       <CardActionArea
-        onClick={() => goToDetails()}
+        onClick={goToDetails}
         classes={{
           root: classes.cardBtn,
           focusHighlight: classes.focusHighlight

--- a/src/components/RepoDetails.jsx
+++ b/src/components/RepoDetails.jsx
@@ -1,9 +1,9 @@
 // react global
-import { useParams } from 'react-router-dom';
 import React, { useEffect, useMemo, useState } from 'react';
 
 // utility
 import { api, endpoints } from '../api';
+import { useParams, useNavigate, createSearchParams } from 'react-router-dom';
 
 // components
 import Tags from './Tags.jsx';
@@ -128,6 +128,7 @@ function RepoDetails() {
   const [selectedTab, setSelectedTab] = useState('Overview');
   // get url param from <Route here (i.e. image name)
   const { name } = useParams();
+  const navigate = useNavigate();
   const abortController = useMemo(() => new AbortController(), []);
   const classes = useStyles();
 
@@ -154,6 +155,13 @@ function RepoDetails() {
     };
   }, [name]);
 
+  const handlePlatformChipClick = (event) => {
+    const { textContent } = event.target;
+    event.stopPropagation();
+    event.preventDefault();
+    navigate({ pathname: `/explore`, search: createSearchParams({ filter: textContent }).toString() });
+  };
+
   const platformChips = () => {
     const platforms = repoDetailData?.platforms || [];
 
@@ -162,6 +170,7 @@ function RepoDetails() {
         <Chip
           key={`${name}${platform?.Os}${index}`}
           label={platform?.Os}
+          onClick={handlePlatformChipClick}
           sx={{
             backgroundColor: '#E0E5EB',
             color: '#52637A',
@@ -171,6 +180,7 @@ function RepoDetails() {
         <Chip
           key={`${name}${platform?.Arch}${index}`}
           label={platform?.Arch}
+          onClick={handlePlatformChipClick}
           sx={{
             backgroundColor: '#E0E5EB',
             color: '#52637A',


### PR DESCRIPTION
Signed-off-by: Raul Kele <raulkeleblk@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Closes #234 
Closes #240 

**What does this PR do / Why do we need it**:
Added support on explore page for preselected filter/sorting order. 
Added logic for clicking OS/Arch chips to redirect to search with the preselected filter
Added view all buttons for the homepage sections to redirect with preselected sort order

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
