### PR TITLE
patch: integrated pagination in cve tab

### DIFF
--- a/src/__tests__/TagPage/VulnerabilitiesDetails.test.js
+++ b/src/__tests__/TagPage/VulnerabilitiesDetails.test.js
@@ -15,6 +15,7 @@ const StateVulnerabilitiesWrapper = () => {
 const mockCVEList = {
   CVEListForImage: {
     Tag: '',
+    Page: { ItemCount: 20, TotalCount: 20 },
     CVEList: [
       {
         Id: 'CVE-2020-16156',
@@ -445,6 +446,17 @@ const mockCVEFixed = {
   ]
 };
 
+beforeEach(() => {
+  // IntersectionObserver isn't available in test environment
+  const mockIntersectionObserver = jest.fn();
+  mockIntersectionObserver.mockReturnValue({
+    observe: () => null,
+    unobserve: () => null,
+    disconnect: () => null
+  });
+  window.IntersectionObserver = mockIntersectionObserver;
+});
+
 afterEach(() => {
   // restore the spy created with spyOn
   jest.restoreAllMocks();
@@ -461,7 +473,7 @@ describe('Vulnerabilties page', () => {
   it('renders no vulnerabilities if there are not any', async () => {
     jest.spyOn(api, 'get').mockResolvedValue({
       status: 200,
-      data: { data: { CVEListForImage: { Tag: '', CVEList: [] } } }
+      data: { data: { CVEListForImage: { Tag: '', Page: {}, CVEList: [] } } }
     });
     render(<StateVulnerabilitiesWrapper />);
     await waitFor(() => expect(screen.getAllByText('No Vulnerabilities')).toHaveLength(1));

--- a/src/api.js
+++ b/src/api.js
@@ -68,8 +68,10 @@ const endpoints = {
     `/v2/_zot/ext/search?query={ExpandedRepoInfo(repo:"${name}"){Images {Digest Vulnerabilities {MaxSeverity Count} Tag LastUpdated Vendor Size Platform {Os Arch}} Summary {Name LastUpdated Size Platforms {Os Arch} Vendors NewestImage {RepoName IsSigned Vulnerabilities {MaxSeverity Count} Layers {Size Digest} Digest Tag Logo Title Documentation DownloadCount Source Description Licenses History {Layer {Size Digest} HistoryDescription {Created CreatedBy Author Comment EmptyLayer}}}}}}`,
   detailedImageInfo: (name, tag) =>
     `/v2/_zot/ext/search?query={Image(image: "${name}:${tag}"){RepoName IsSigned Vulnerabilities {MaxSeverity Count} Tag Digest LastUpdated Size ConfigDigest Platform {Os Arch} Vendor Licenses Logo}}`,
-  vulnerabilitiesForRepo: (name) =>
-    `/v2/_zot/ext/search?query={CVEListForImage(image: "${name}"){Tag, CVEList {Id Title Description Severity PackageList {Name InstalledVersion FixedVersion}}}}`,
+  vulnerabilitiesForRepo: (name, { pageNumber = 1, pageSize = 15 }) =>
+    `/v2/_zot/ext/search?query={CVEListForImage(image: "${name}", requestedPage: {limit:${pageSize} offset:${
+      (pageNumber - 1) * pageSize
+    }}){Tag Page {TotalCount ItemCount} CVEList {Id Title Description Severity PackageList {Name InstalledVersion FixedVersion}}}}`,
   layersDetailsForImage: (name) =>
     `/v2/_zot/ext/search?query={Image(image: "${name}"){History {Layer {Size Digest Score} HistoryDescription {Created CreatedBy Author Comment EmptyLayer} }}}`,
   imageListWithCVEFixed: (cveId, repoName) =>

--- a/src/components/TagDetails.jsx
+++ b/src/components/TagDetails.jsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState, useRef } from 'react';
 
 // utility
 import { api, endpoints } from '../api';
@@ -214,6 +214,7 @@ function TagDetails() {
   const [selectedTab, setSelectedTab] = useState('Layers');
   const [selectedPullTab, setSelectedPullTab] = useState('');
   const abortController = useMemo(() => new AbortController(), []);
+  const mounted = useRef(false);
 
   // get url param from <Route here (i.e. image name)
   const { reponame, tag } = useParams();
@@ -223,6 +224,7 @@ function TagDetails() {
   const classes = useStyles();
 
   useEffect(() => {
+    mounted.current = true;
     // if same-page navigation because of tag update, following 2 lines help ux
     setSelectedTab('Layers');
     window?.scrollTo(0, 0);
@@ -246,6 +248,7 @@ function TagDetails() {
       });
     return () => {
       abortController.abort();
+      mounted.current = false;
     };
   }, [reponame, tag]);
 
@@ -265,7 +268,9 @@ function TagDetails() {
   useEffect(() => {
     if (isCopied) {
       setTimeout(() => {
-        setIsCopied(false);
+        if (mounted.current) {
+          setIsCopied(false);
+        }
       }, 3000);
     }
   }, [isCopied]);

--- a/src/utilities/objectModels.js
+++ b/src/utilities/objectModels.js
@@ -60,7 +60,7 @@ const mapToImage = (responseImage) => {
 };
 
 const mapCVEInfo = (cveInfo) => {
-  const cveList = cveInfo.CVEList?.map((cve) => {
+  const cveList = cveInfo.map((cve) => {
     return {
       id: cve.Id,
       severity: cve.Severity,
@@ -68,9 +68,7 @@ const mapCVEInfo = (cveInfo) => {
       description: cve.Description
     };
   });
-  return {
-    cveList
-  };
+  return cveList;
 };
 
 const mapReferrer = (referrer) => ({


### PR DESCRIPTION
Signed-off-by: Raul Kele <raulkeleblk@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Closes #284 

**What does this PR do / Why do we need it**:
Integrates the new CVEListForImage query pagination changes into the ui

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
