### PR TITLE
fix: redirect to home if data invalid on repo or tag page

### DIFF
--- a/src/__tests__/RepoPage/Repo.test.js
+++ b/src/__tests__/RepoPage/Repo.test.js
@@ -282,6 +282,12 @@ describe('Repo details component', () => {
     await waitFor(() => expect(error).toBeCalledTimes(1));
   });
 
+  it('should redirect to homepage if it receives invalid data', async () => {
+    jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: { data: null, errors: ['testerror'] } });
+    render(<RepoDetailsThemeWrapper />);
+    await waitFor(() => expect(mockUseNavigate).toBeCalledWith('/home'));
+  });
+
   it('should switch between tabs', async () => {
     jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: { data: mockRepoDetailsData } });
     render(<RepoDetailsThemeWrapper />);

--- a/src/__tests__/TagPage/TagDetails.test.js
+++ b/src/__tests__/TagPage/TagDetails.test.js
@@ -18,6 +18,8 @@ const TagDetailsThemeWrapper = () => {
   );
 };
 
+const mockUseNavigate = jest.fn();
+
 const mockImage = {
   Image: {
     RepoName: 'centos',
@@ -250,7 +252,8 @@ jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useParams: () => {
     return { name: 'test', tag: '1.0.1' };
-  }
+  },
+  useNavigate: () => mockUseNavigate
 }));
 
 jest.mock('../../host', () => ({
@@ -291,6 +294,12 @@ describe('Tags details', () => {
     const error = jest.spyOn(console, 'error').mockImplementation(() => {});
     render(<TagDetailsThemeWrapper />);
     await waitFor(() => expect(error).toBeCalledTimes(1));
+  });
+
+  it('should redirect to homepage if it receives invalid data', async () => {
+    jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: { data: null, errors: ['testerror'] } });
+    render(<TagDetailsThemeWrapper />);
+    await waitFor(() => expect(mockUseNavigate).toBeCalledWith('/home'));
   });
 
   it('should show tag details metadata', async () => {

--- a/src/components/Repo/RepoDetails.jsx
+++ b/src/components/Repo/RepoDetails.jsx
@@ -172,6 +172,8 @@ function RepoDetails() {
           let imageData = mapToRepoFromRepoInfo(repoInfo);
           setRepoDetailData(imageData);
           setTags(imageData.images);
+        } else if (!isEmpty(response.data.errors)) {
+          navigate('/home');
         }
         setIsLoading(false);
       })

--- a/src/components/Tag/TagDetails.jsx
+++ b/src/components/Tag/TagDetails.jsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import React, { useEffect, useMemo, useState, useRef } from 'react';
 
 // utility
@@ -217,6 +217,7 @@ function TagDetails() {
   const [selectedPullTab, setSelectedPullTab] = useState('');
   const abortController = useMemo(() => new AbortController(), []);
   const mounted = useRef(false);
+  const navigate = useNavigate();
 
   // get url param from <Route here (i.e. image name)
   const { reponame, tag } = useParams();
@@ -240,6 +241,8 @@ function TagDetails() {
           setImageDetailData(imageData);
           setPullString(dockerPull(imageData.name));
           setSelectedPullTab(dockerPull(imageData.name));
+        } else if (!isEmpty(response.data.errors)) {
+          navigate('/home');
         }
         setIsLoading(false);
       })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Closes #305 

**What does this PR do / Why do we need it**:
If the user lands on the page of a repo or a tag that doesn't exist, for example, by changing the url directly, the app will redirect the use back to the home page

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
