### PR TITLE
patch: referrers from image query

### DIFF
--- a/src/__tests__/TagPage/ReferredBy.test.js
+++ b/src/__tests__/TagPage/ReferredBy.test.js
@@ -1,47 +1,42 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { api } from 'api';
 import ReferredBy from 'components/Tag/Tabs/ReferredBy';
 import React from 'react';
 
-const mockReferrersList = {
-  data: {
-    Referrers: [
+const mockReferrersList = [
+  {
+    MediaType: 'application/vnd.oci.artifact.manifest.v1+json',
+    ArtifactType: 'application/vnd.example.icecream.v1',
+    Size: 466,
+    Digest: 'sha256:be7a3d01c35a2cf53c502e9dc50cdf36b15d9361c81c63bf319f1d5cbe44ab7c',
+    Annotations: [
       {
-        MediaType: 'application/vnd.oci.artifact.manifest.v1+json',
-        ArtifactType: 'application/vnd.example.icecream.v1',
-        Size: 466,
-        Digest: 'sha256:be7a3d01c35a2cf53c502e9dc50cdf36b15d9361c81c63bf319f1d5cbe44ab7c',
-        Annotations: [
-          {
-            Key: 'demo',
-            Value: 'true'
-          },
-          {
-            Key: 'format',
-            Value: 'oci'
-          }
-        ]
+        Key: 'demo',
+        Value: 'true'
       },
       {
-        MediaType: 'application/vnd.oci.artifact.manifest.v1+json',
-        ArtifactType: 'application/vnd.example.icecream.v1',
-        Size: 466,
-        Digest: 'sha256:d9ad22f41d9cb9797c134401416eee2a70446cee1a8eb76fc6b191f4320dade2',
-        Annotations: [
-          {
-            Key: 'demo',
-            Value: 'true'
-          },
-          {
-            Key: 'format',
-            Value: 'oci'
-          }
-        ]
+        Key: 'format',
+        Value: 'oci'
+      }
+    ]
+  },
+  {
+    MediaType: 'application/vnd.oci.artifact.manifest.v1+json',
+    ArtifactType: 'application/vnd.example.icecream.v1',
+    Size: 466,
+    Digest: 'sha256:d9ad22f41d9cb9797c134401416eee2a70446cee1a8eb76fc6b191f4320dade2',
+    Annotations: [
+      {
+        Key: 'demo',
+        Value: 'true'
+      },
+      {
+        Key: 'format',
+        Value: 'oci'
       }
     ]
   }
-};
+];
 
 // useNavigate mock
 const mockedUsedNavigate = jest.fn();
@@ -57,27 +52,17 @@ afterEach(() => {
 
 describe('Referred by tab', () => {
   it('should render referrers if there are any', async () => {
-    jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: mockReferrersList });
-    render(<ReferredBy repoName="golang" digest="test" />);
+    render(<ReferredBy referrers={mockReferrersList} />);
     expect(await screen.findAllByText('Media type: application/vnd.oci.artifact.manifest.v1+json')).toHaveLength(2);
   });
 
   it("renders no referrers if there aren't any", async () => {
-    jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: { data: { Referrers: [] } } });
-    render(<ReferredBy repoName="golang" digest="test" />);
+    render(<ReferredBy referrers={[]} />);
     expect(await screen.findByText(/Nothing found/i)).toBeInTheDocument();
   });
 
-  it('should log an error if the request fails', async () => {
-    jest.spyOn(api, 'get').mockRejectedValue({ status: 500, data: {} });
-    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
-    render(<ReferredBy repoName="golang" digest="test" />);
-    await waitFor(() => expect(error).toBeCalledTimes(1));
-  });
-
   it('should display the digest when clicking the dropdowns', async () => {
-    jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: mockReferrersList });
-    render(<ReferredBy repoName="golang" digest="test" />);
+    render(<ReferredBy referrers={mockReferrersList} />);
     const firstDigest = (await screen.findAllByText(/digest/i))[0];
     expect(firstDigest).toBeInTheDocument();
     await userEvent.click(firstDigest);
@@ -91,8 +76,7 @@ describe('Referred by tab', () => {
   });
 
   it('should display the annotations when clicking the dropdown', async () => {
-    jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: mockReferrersList });
-    render(<ReferredBy repoName="golang" digest="test" />);
+    render(<ReferredBy referrers={mockReferrersList} />);
     const firstAnnotations = (await screen.findAllByText(/ANNOTATIONS/i))[0];
     expect(firstAnnotations).toBeInTheDocument();
     await userEvent.click(firstAnnotations);

--- a/src/api.js
+++ b/src/api.js
@@ -78,7 +78,7 @@ const endpoints = {
   detailedRepoInfo: (name) =>
     `/v2/_zot/ext/search?query={ExpandedRepoInfo(repo:"${name}"){Images {Manifests {Digest Platform {Os Arch} Size} Vulnerabilities {MaxSeverity Count} Tag LastUpdated Vendor } Summary {Name LastUpdated Size Platforms {Os Arch} Vendors NewestImage {RepoName IsSigned Vulnerabilities {MaxSeverity Count} Manifests {Digest} Tag Title Documentation DownloadCount Source Description Licenses}}}}`,
   detailedImageInfo: (name, tag) =>
-    `/v2/_zot/ext/search?query={Image(image: "${name}:${tag}"){RepoName IsSigned Vulnerabilities {MaxSeverity Count} Tag Manifests {History {Layer {Size Digest} HistoryDescription {CreatedBy EmptyLayer}} Digest ConfigDigest LastUpdated Size  Platform {Os Arch}} Vendor Licenses }}`,
+    `/v2/_zot/ext/search?query={Image(image: "${name}:${tag}"){RepoName IsSigned Vulnerabilities {MaxSeverity Count}  Referrers {MediaType ArtifactType Size Digest Annotations{Key Value}} Tag Manifests {History {Layer {Size Digest} HistoryDescription {CreatedBy EmptyLayer}} Digest ConfigDigest LastUpdated Size Platform {Os Arch}} Vendor Licenses }}`,
   vulnerabilitiesForRepo: (name, { pageNumber = 1, pageSize = 15 }, searchTerm = '') => {
     let query = `/v2/_zot/ext/search?query={CVEListForImage(image: "${name}", requestedPage: {limit:${pageSize} offset:${
       (pageNumber - 1) * pageSize

--- a/src/components/Tag/Tabs/ReferredBy.jsx
+++ b/src/components/Tag/Tabs/ReferredBy.jsx
@@ -1,11 +1,9 @@
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useEffect, useState } from 'react';
 import { makeStyles } from '@mui/styles';
 import { isEmpty } from 'lodash';
 import { Divider, Typography, Stack } from '@mui/material';
 import ReferrerCard from '../../Shared/ReferrerCard';
 import Loading from '../../Shared/Loading';
-import { api, endpoints } from 'api';
-import { host } from '../../../host';
 import { mapReferrer } from 'utilities/objectModels';
 
 const useStyles = makeStyles(() => ({
@@ -17,36 +15,24 @@ const useStyles = makeStyles(() => ({
 }));
 
 function ReferredBy(props) {
-  const { repoName, digest } = props;
-  const [referrers, setReferrers] = useState([]);
+  const { referrers } = props;
+  const [referrersData, setReferrersData] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const classes = useStyles();
-  const abortController = useMemo(() => new AbortController(), []);
 
   useEffect(() => {
-    api
-      .get(`${host()}${endpoints.referrers({ repo: repoName, digest })}`, abortController.signal)
-      .then((response) => {
-        if (response.data && response.data.data) {
-          let referrersData = response.data.data.Referrers?.map((referrer) => mapReferrer(referrer));
-          if (!isEmpty(referrersData)) {
-            setReferrers(referrersData);
-          }
-        }
-        setIsLoading(false);
-      })
-      .catch((e) => {
-        console.error(e);
-        setIsLoading(false);
-      });
-    return () => {
-      abortController.abort();
-    };
+    if (!isEmpty(referrers)) {
+      const mappedReferrersData = referrers.map((referrer) => mapReferrer(referrer));
+      setReferrersData(mappedReferrersData);
+    } else {
+      setReferrersData([]);
+    }
+    setIsLoading(false);
   }, []);
 
   const renderReferrers = () => {
-    return !isEmpty(referrers) ? (
-      referrers.map((referrer, index) => {
+    return !isEmpty(referrersData) ? (
+      referrersData.map((referrer, index) => {
         return (
           <ReferrerCard
             key={index}
@@ -61,16 +47,6 @@ function ReferredBy(props) {
     ) : (
       <div>{!isLoading && <Typography className={classes.none}> Nothing found </Typography>}</div>
     );
-  };
-
-  const renderListBottom = () => {
-    if (isLoading) {
-      return <Loading />;
-    }
-    if (!isLoading) {
-      return <div />;
-    }
-    return;
   };
 
   return (
@@ -95,8 +71,7 @@ function ReferredBy(props) {
       />
       <Stack direction="column" spacing={2}>
         <Stack direction="column" spacing={2}>
-          {renderReferrers()}
-          {renderListBottom()}
+          {isLoading ? <Loading /> : renderReferrers()}
         </Stack>
       </Stack>
     </div>

--- a/src/components/Tag/TagDetails.jsx
+++ b/src/components/Tag/TagDetails.jsx
@@ -580,7 +580,7 @@ function TagDetails() {
                             <VulnerabilitiesDetails name={reponame} tag={tag} />
                           </TabPanel>
                           <TabPanel value="ReferredBy" className={classes.tabPanel}>
-                            <ReferredBy repoName={reponame} digest={selectedManifest?.digest} />
+                            <ReferredBy referrers={imageDetailData.referrers} />
                           </TabPanel>
                         </Grid>
                       </Grid>

--- a/src/utilities/objectModels.js
+++ b/src/utilities/objectModels.js
@@ -44,6 +44,7 @@ const mapToImage = (responseImage) => {
     repoName: responseImage.RepoName,
     tag: responseImage.Tag,
     manifests: responseImage.Manifests?.map((manifest) => mapToManifest(manifest)) || [],
+    referrers: responseImage.Referrers,
     size: responseImage.Size,
     downloadCount: responseImage.DownloadCount,
     lastUpdated: responseImage.LastUpdated,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
patch
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Closes #326 

**What does this PR do / Why do we need it**:
Updates zui's usage of the backend API to consume referrers from the image query as opposed to making a separate query for the referrers

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
