### PR TITLE
fix: login bug when both anonymous and auth is enabled

### DIFF
--- a/src/components/Login/SignIn.jsx
+++ b/src/components/Login/SignIn.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { host } from '../../host';
 // utility
 import { api, endpoints } from '../../api';
-import { isEmpty } from 'lodash';
+import { isEmpty, isNil } from 'lodash';
 
 // components
 import Button from '@mui/material/Button';
@@ -142,17 +142,18 @@ export default function SignIn({ isLoggedIn, setIsLoggedIn, wrapperSetLoading = 
     event.preventDefault();
     setRequestProcessing(true);
     let cfg = {};
-    const token = btoa(username + ':' + password);
-    cfg = {
-      headers: {
-        Authorization: `Basic ${token}`
-      }
-    };
+    let token = !isNil(username) && !isNil(password) ? btoa(username + ':' + password) : '-';
+    if (token !== '-') {
+      cfg = {
+        headers: {
+          Authorization: `Basic ${token}`
+        }
+      };
+    }
     api
       .get(`${host()}/v2/`, abortController.signal, cfg)
       .then((response) => {
         if (response.status === 200) {
-          const token = btoa(username + ':' + password);
           localStorage.setItem('token', token);
           setRequestProcessing(false);
           setRequestError(false);

--- a/tests/tag.spec.js
+++ b/tests/tag.spec.js
@@ -1,7 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { getTagWithDependencies, getTagWithDependents, getTagWithVulnerabilities } from './utils/test-data-parser';
 import { hosts, pageSizes } from './values/test-constants';
-import { scroll } from './utils/scroll';
 
 test.describe('Tag page test', () => {
   test.beforeEach(async ({ page }) => {
@@ -39,7 +38,5 @@ test.describe('Tag page test', () => {
     await expect(page.getByTestId('vulnerability-container').locator('div').nth(1)).toBeVisible({ timeout: 100000 });
     await expect(await page.getByText('CVE-').count()).toBeGreaterThan(1);
     await expect(await page.getByText('CVE-').count()).toBeLessThanOrEqual(pageSizes.EXPLORE);
-    await page.evaluate(scroll, { direction: 'down', speed: 'fast' });
-    await expect(await page.getByText('CVE-').count()).toBeGreaterThanOrEqual(pageSizes.EXPLORE);
   });
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
