### PR TITLE
feat: add freebsd as an OS filter (#407)

### DIFF
--- a/src/__tests__/Explore/FilterCard.test.js
+++ b/src/__tests__/Explore/FilterCard.test.js
@@ -21,7 +21,7 @@ const StateFilterCardWrapper = () => {
 describe('Filters components', () => {
   it('renders the filters cards', async () => {
     render(<StateFilterCardWrapper />);
-    expect(screen.getAllByRole('checkbox')).toHaveLength(2);
+    expect(screen.getAllByRole('checkbox')).toHaveLength(3);
 
     const checkbox = screen.getAllByRole('checkbox');
     expect(checkbox[0]).not.toBeChecked();

--- a/src/utilities/filterConstants.js
+++ b/src/utilities/filterConstants.js
@@ -6,6 +6,10 @@ const osFilters = [
   {
     label: 'linux',
     value: 'linux'
+  },
+  {
+    label: 'freebsd',
+    value: 'freebsd'
   }
 ];
 

--- a/tests/explore.spec.js
+++ b/tests/explore.spec.js
@@ -76,8 +76,14 @@ test.describe('explore page test', () => {
 
     await expect(exploreFirst).toBeVisible({ timeout: 250000 });
 
+    const windowsFilter = page.getByRole('checkbox', { name: 'windows' });
     await linuxFilter.uncheck();
-    await page.getByRole('checkbox', { name: 'windows' }).check();
+    await windowsFilter.check();
+    await expect(exploreFirst).not.toBeVisible({ timeout: 250000 });
+
+    const freebsdFilter = page.getByRole('checkbox', { name: 'freebsd' });
+    await windowsFilter.uncheck();
+    await freebsdFilter.check();
     await expect(exploreFirst).not.toBeVisible({ timeout: 250000 });
   });
 });


### PR DESCRIPTION
**What type of PR is this?**

feature

**Which issue does this PR fix**:
#407 

**What does this PR do / Why do we need it**:
It is useful to be able to filter by OS and I typically have both linux and freebsd images in my repositories.

**Testing done on this change**:
Ad-hoc testing with zot. I added a test for filtering for freebsd, similar to windows but haven't managed to run that test locally. Hopefully CI will work though.

**Automation added to e2e**:
I modified the 'explore filtering' test to add checks for freebsd as a filter.

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No and no.

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
The user will see freebsd listed as an OS filter.

```release-note
Add "freebsd" as an operating system filter.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
