### PR TITLE
chore: upgrade to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -135,7 +135,7 @@ jobs:
         make integration-tests REGISTRY_HOST=$REGISTRY_HOST REGISTRY_PORT=$REGISTRY_PORT
 
     - name: Upload playwright report
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: playwright-report
         path: playwright-report/


### PR DESCRIPTION
Artifact actions v3 will be closing down by January 30, 2025.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
