### PR TITLE
fix: show referrers pointing to image manifests

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -136,6 +136,7 @@ jobs:
 
     - name: Upload playwright report
       uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: playwright-report
         path: playwright-report/

--- a/src/api.js
+++ b/src/api.js
@@ -93,7 +93,7 @@ const endpoints = {
   detailedRepoInfo: (name) =>
     `/v2/_zot/ext/search?query={ExpandedRepoInfo(repo:"${name}"){Images {Manifests {Digest Platform {Os Arch} Size} Vulnerabilities {MaxSeverity Count} Tag LastUpdated Vendor IsDeletable } Summary {Name LastUpdated Size Platforms {Os Arch} Vendors IsStarred IsBookmarked NewestImage {RepoName IsSigned SignatureInfo { Tool IsTrusted Author } Vulnerabilities {MaxSeverity Count} Manifests {Digest} Tag Vendor Title Documentation DownloadCount Source Description Licenses}}}}`,
   detailedImageInfo: (name, tag) =>
-    `/v2/_zot/ext/search?query={Image(image: "${name}:${tag}"){RepoName IsSigned SignatureInfo { Tool IsTrusted Author } Vulnerabilities {MaxSeverity Count}  Referrers {MediaType ArtifactType Size Digest Annotations{Key Value}} Tag Manifests {History {Layer {Size Digest} HistoryDescription {CreatedBy EmptyLayer}} Digest ConfigDigest LastUpdated Size Platform {Os Arch}} Vendor Licenses }}`,
+    `/v2/_zot/ext/search?query={Image(image: "${name}:${tag}"){RepoName IsSigned SignatureInfo { Tool IsTrusted Author } Vulnerabilities {MaxSeverity Count}  Referrers {MediaType ArtifactType Size Digest Annotations{Key Value}} Tag Manifests {History {Layer {Size Digest} HistoryDescription {CreatedBy EmptyLayer}} Digest ConfigDigest LastUpdated Size Platform {Os Arch} Referrers {MediaType ArtifactType Size Digest Annotations{Key Value}}} Vendor Licenses }}`,
   vulnerabilitiesForRepo: (
     name,
     { pageNumber = 1, pageSize = 15 },

--- a/src/components/Tag/TagDetails.jsx
+++ b/src/components/Tag/TagDetails.jsx
@@ -6,7 +6,7 @@ import { api, endpoints } from '../../api';
 import { host } from '../../host';
 import { mapToImage } from '../../utilities/objectModels';
 import filterConstants from 'utilities/filterConstants';
-import { isEmpty, head } from 'lodash';
+import { isEmpty, head, uniqBy } from 'lodash';
 
 // components
 import {
@@ -219,7 +219,12 @@ function TagDetails() {
           />
         );
       case 'ReferredBy':
-        return <ReferredBy referrers={imageDetailData?.referrers} />;
+        const allReferrers = uniqBy(
+          [...(selectedManifest?.referrers || []), ...(imageDetailData?.referrers || [])],
+          'digest'
+        );
+
+        return <ReferredBy referrers={allReferrers} />;
       default:
         return <HistoryLayers name={imageDetailData?.name} history={selectedManifest?.history || []} />;
     }

--- a/src/components/Tag/TagDetails.jsx
+++ b/src/components/Tag/TagDetails.jsx
@@ -353,7 +353,12 @@ function TagDetails() {
           </Grid>
           <Grid item xs={12} md={8}>
             <Card className={classes.cardRoot}>
-              <CardContent className={classes.tabCardContent}>{renderTabContent()}</CardContent>
+              <CardContent
+                key={`card_content_manifest_key_${selectedManifest?.digest}`}
+                className={classes.tabCardContent}
+              >
+                {renderTabContent()}
+              </CardContent>
             </Card>
           </Grid>
           <Grid item xs={12} md={4} className={classes.metadata}>

--- a/src/utilities/objectModels.js
+++ b/src/utilities/objectModels.js
@@ -86,7 +86,8 @@ const mapToManifest = (responseManifest) => {
     starCount: responseManifest.StarCount,
     layers: responseManifest.Layers,
     history: responseManifest.History,
-    vulnerabilities: responseManifest.Vulnerabilities
+    vulnerabilities: responseManifest.Vulnerabilities,
+    referrers: responseManifest.Referrers
   };
 };
 

--- a/tests/values/test-constants.js
+++ b/tests/values/test-constants.js
@@ -25,7 +25,7 @@ const endpoints = {
       10 * (pageNumber - 1)
     }%20sortBy:%20${sortCriteria}}%20)%20{Page%20{TotalCount%20ItemCount}%20Repos%20{Name%20LastUpdated%20Size%20Platforms%20{%20Os%20Arch%20}%20IsStarred%20IsBookmarked%20NewestImage%20{%20Tag%20Vulnerabilities%20{MaxSeverity%20Count}%20Description%20IsSigned%20SignatureInfo%20{%20Tool%20IsTrusted%20Author%20}%20Licenses%20Vendor%20Labels%20}%20StarCount%20DownloadCount}}}`,
   image: (name) =>
-    `/v2/_zot/ext/search?query={Image(image:%20%22${name}%22){RepoName%20IsSigned%20SignatureInfo%20{%20Tool%20IsTrusted%20Author%20}%20Vulnerabilities%20{MaxSeverity%20Count}%20%20Referrers%20{MediaType%20ArtifactType%20Size%20Digest%20Annotations{Key%20Value}}%20Tag%20Manifests%20{History%20{Layer%20{Size%20Digest}%20HistoryDescription%20{CreatedBy%20EmptyLayer}}%20Digest%20ConfigDigest%20LastUpdated%20Size%20Platform%20{Os%20Arch}}%20Vendor%20Licenses%20}}`
+    `/v2/_zot/ext/search?query={Image(image:%20%22${name}%22){RepoName%20IsSigned%20SignatureInfo%20{%20Tool%20IsTrusted%20Author%20}%20Vulnerabilities%20{MaxSeverity%20Count}%20%20Referrers%20{MediaType%20ArtifactType%20Size%20Digest%20Annotations{Key%20Value}}%20Tag%20Manifests%20{History%20{Layer%20{Size%20Digest}%20HistoryDescription%20{CreatedBy%20EmptyLayer}}%20Digest%20ConfigDigest%20LastUpdated%20Size%20Platform%20{Os%20Arch}%20Referrers%20{MediaType%20ArtifactType%20Size%20Digest%20Annotations{Key%20Value}}}%20Vendor%20Licenses%20}}`
 };
 
 export { hosts, endpoints, sortCriteria, pageSizes };


### PR DESCRIPTION
See https://github.com/project-zot/zui/issues/476

In previous implementations the referrers tab only showed the referrers returned at image level, ignoring the referrers returned at manifest level. This is fine for singlearch images, since they are the same. For images containing multiple manifests only index referrers were shown.

The current implementation would show both the referrers to the index and the current manifest.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
