### PR TITLE
feat: add Last Tagged timestamp to tag details view

### DIFF
--- a/src/__tests__/TagPage/TagDetails.test.jsx
+++ b/src/__tests__/TagPage/TagDetails.test.jsx
@@ -24,6 +24,7 @@ const mockImage = {
   Image: {
     RepoName: 'centos',
     Tag: '8',
+    TaggedTimestamp: '2020-12-10T00:22:52.526672082Z',
     Manifests: [
       {
         Digest: 'sha256:63a795ca90aa6e7cca60941e826810a4cd0a2e73ea02bf458241df2a5c973e29',
@@ -219,6 +220,7 @@ const mockImageUnknown = {
   Image: {
     RepoName: 'centos',
     Tag: '8',
+    TaggedTimestamp: '2020-12-10T00:22:52.526672082Z',
     Manifests: [
       {
         Digest: 'sha256:63a795ca90aa6e7cca60941e826810a4cd0a2e73ea02bf458241df2a5c973e29',
@@ -243,6 +245,7 @@ const mockImageFailed = {
   Image: {
     RepoName: 'centos',
     Tag: '8',
+    TaggedTimestamp: '2020-12-10T00:22:52.526672082Z',
     Manifests: [
       {
         Digest: 'sha256:63a795ca90aa6e7cca60941e826810a4cd0a2e73ea02bf458241df2a5c973e29',
@@ -267,6 +270,7 @@ const mockImageLow = {
   Image: {
     RepoName: 'centos',
     Tag: '8',
+    TaggedTimestamp: '2020-12-10T00:22:52.526672082Z',
     Manifests: [
       {
         Digest: 'sha256:63a795ca90aa6e7cca60941e826810a4cd0a2e73ea02bf458241df2a5c973e29',
@@ -291,6 +295,7 @@ const mockImageMedium = {
   Image: {
     RepoName: 'centos',
     Tag: '8',
+    TaggedTimestamp: '2020-12-10T00:22:52.526672082Z',
     Manifests: [
       {
         Digest: 'sha256:63a795ca90aa6e7cca60941e826810a4cd0a2e73ea02bf458241df2a5c973e29',
@@ -315,6 +320,7 @@ const mockImageHigh = {
   Image: {
     RepoName: 'centos',
     Tag: '8',
+    TaggedTimestamp: '2020-12-10T00:22:52.526672082Z',
     Manifests: [
       {
         Digest: 'sha256:63a795ca90aa6e7cca60941e826810a4cd0a2e73ea02bf458241df2a5c973e29',
@@ -944,6 +950,43 @@ describe('Tags details', () => {
     jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: { data: mockImage } });
     render(<TagDetailsThemeWrapper />);
     expect(await screen.findByTestId('tagDetailsMetadata-container')).toBeInTheDocument();
+  });
+
+  it('should display "Created" label in tag details metadata', async () => {
+    jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: { data: mockImage } });
+    render(<TagDetailsThemeWrapper />);
+    expect(await screen.findByText('Created')).toBeInTheDocument();
+  });
+
+  it('should display "Last Tagged" label and formatted timestamp when TaggedTimestamp is available', async () => {
+    jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: { data: mockImage } });
+    render(<TagDetailsThemeWrapper />);
+    const lastTaggedLabel = await screen.findByText('Last Tagged');
+    expect(lastTaggedLabel).toBeInTheDocument();
+
+    // Verify the formatted timestamp is displayed (should be relative time like "X weeks ago" or "Timestamp N/A")
+    // The timestamp from mockImage is '2020-12-10T00:22:52.526672082Z' which should be formatted
+    const metadataContainer = await screen.findByTestId('tagDetailsMetadata-container');
+    expect(metadataContainer).toBeInTheDocument();
+    // Check that the formatted date text is present (not just the label)
+    // The formatted date should be in the same card as "Last Tagged"
+    const lastTaggedCard = lastTaggedLabel.closest('.MuiCard-root');
+    expect(lastTaggedCard).toBeInTheDocument();
+    // The formatted date should not be "Timestamp N/A" since we have a valid timestamp
+    const formattedDate = lastTaggedCard?.textContent;
+    expect(formattedDate).not.toContain('Timestamp N/A');
+  });
+
+  it('should display "Timestamp N/A" when TaggedTimestamp is undefined', async () => {
+    jest.spyOn(api, 'get').mockResolvedValue({ status: 200, data: { data: mockImageNone } });
+    render(<TagDetailsThemeWrapper />);
+    const lastTaggedLabel = await screen.findByText('Last Tagged');
+    expect(lastTaggedLabel).toBeInTheDocument();
+
+    // Verify the fallback "Timestamp N/A" is displayed when TaggedTimestamp is missing
+    const lastTaggedCard = lastTaggedLabel.closest('.MuiCard-root');
+    expect(lastTaggedCard).toBeInTheDocument();
+    expect(lastTaggedCard?.textContent).toContain('Timestamp N/A');
   });
 
   it('renders vulnerability icons', async () => {

--- a/src/api.js
+++ b/src/api.js
@@ -93,7 +93,7 @@ const endpoints = {
   detailedRepoInfo: (name) =>
     `/v2/_zot/ext/search?query={ExpandedRepoInfo(repo:"${name}"){Images {Manifests {Digest Platform {Os Arch} Size} Vulnerabilities {MaxSeverity Count} Tag LastUpdated Vendor IsDeletable } Summary {Name LastUpdated Size Platforms {Os Arch} Vendors IsStarred IsBookmarked NewestImage {RepoName IsSigned SignatureInfo { Tool IsTrusted Author } Vulnerabilities {MaxSeverity Count} Manifests {Digest} Tag Vendor Title Documentation DownloadCount Source Description Licenses}}}}`,
   detailedImageInfo: (name, tag) =>
-    `/v2/_zot/ext/search?query={Image(image: "${name}:${tag}"){RepoName IsSigned SignatureInfo { Tool IsTrusted Author } Vulnerabilities {MaxSeverity Count}  Referrers {MediaType ArtifactType Size Digest Annotations{Key Value}} Tag Manifests {History {Layer {Size Digest} HistoryDescription {CreatedBy EmptyLayer}} Digest ConfigDigest LastUpdated Size Platform {Os Arch} Referrers {MediaType ArtifactType Size Digest Annotations{Key Value}}} Vendor Licenses }}`,
+    `/v2/_zot/ext/search?query={Image(image: "${name}:${tag}"){RepoName IsSigned SignatureInfo { Tool IsTrusted Author } Vulnerabilities {MaxSeverity Count}  Referrers {MediaType ArtifactType Size Digest Annotations{Key Value}} Tag TaggedTimestamp Manifests {History {Layer {Size Digest} HistoryDescription {CreatedBy EmptyLayer}} Digest ConfigDigest LastUpdated Size Platform {Os Arch} Referrers {MediaType ArtifactType Size Digest Annotations{Key Value}}} Vendor Licenses }}`,
   vulnerabilitiesForRepo: (
     name,
     { pageNumber = 1, pageSize = 15 },

--- a/src/components/Tag/TagDetails.jsx
+++ b/src/components/Tag/TagDetails.jsx
@@ -366,6 +366,7 @@ function TagDetails() {
               platform={getPlatform()}
               size={selectedManifest?.size}
               lastUpdated={selectedManifest?.lastUpdated}
+              lastTagged={imageDetailData?.lastTagged}
               license={imageDetailData?.license}
               imageName={imageDetailData?.name}
             />

--- a/src/components/Tag/TagDetailsMetadata.jsx
+++ b/src/components/Tag/TagDetailsMetadata.jsx
@@ -52,10 +52,14 @@ const useStyles = makeStyles((theme) => ({
 
 function TagDetailsMetadata(props) {
   const classes = useStyles();
-  const { platform, lastUpdated, size, license, imageName } = props;
+  const { platform, lastUpdated, lastTagged, size, license, imageName } = props;
 
   const lastDate = lastUpdated
     ? DateTime.fromISO(lastUpdated).toRelative({ unit: ['weeks', 'days', 'hours', 'minutes'] })
+    : `Timestamp N/A`;
+
+  const lastTaggedDate = lastTagged
+    ? DateTime.fromISO(lastTagged).toRelative({ unit: ['weeks', 'days', 'hours', 'minutes'] })
     : `Timestamp N/A`;
 
   return (
@@ -96,11 +100,25 @@ function TagDetailsMetadata(props) {
           <Card variant="outlined" className={classes.card}>
             <CardContent className={classes.cardContent}>
               <Typography variant="body2" align="left" className={classes.metadataHeader}>
-                Last Published
+                Created
               </Typography>
               <Tooltip title={lastUpdated?.slice(0, 16) || ' '} placement="top">
                 <Typography variant="body1" align="left" className={classes.metadataBody}>
                   {lastDate}
+                </Typography>
+              </Tooltip>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid item xs={12}>
+          <Card variant="outlined" className={classes.card}>
+            <CardContent className={classes.cardContent}>
+              <Typography variant="body2" align="left" className={classes.metadataHeader}>
+                Last Tagged
+              </Typography>
+              <Tooltip title={lastTagged?.slice(0, 16) || ' '} placement="top">
+                <Typography variant="body1" align="left" className={classes.metadataBody}>
+                  {lastTaggedDate}
                 </Typography>
               </Tooltip>
             </CardContent>

--- a/src/utilities/__tests__/objectModels.test.js
+++ b/src/utilities/__tests__/objectModels.test.js
@@ -1,0 +1,100 @@
+import { mapToImage, mapToManifest } from '../objectModels';
+
+describe('objectModels', () => {
+  describe('mapToImage', () => {
+    it('should map TaggedTimestamp to lastTagged', () => {
+      const responseImage = {
+        RepoName: 'test-repo',
+        Tag: 'latest',
+        TaggedTimestamp: '2020-12-10T00:22:52.526672082Z',
+        LastUpdated: '2020-12-08T00:22:52.526672082Z',
+        Manifests: [],
+        Referrers: [],
+        Size: '1000',
+        DownloadCount: 10,
+        StarCount: 5,
+        Description: 'Test description',
+        IsSigned: false,
+        SignatureInfo: [],
+        Licenses: 'MIT',
+        Labels: [],
+        Title: 'Test Title',
+        Source: 'https://example.com',
+        Documentation: 'Test docs',
+        Vendor: 'Test Vendor',
+        Authors: [],
+        Vulnerabilities: { MaxSeverity: 'NONE', Count: 0 },
+        IsDeletable: true
+      };
+
+      const result = mapToImage(responseImage);
+
+      expect(result.lastTagged).toBe('2020-12-10T00:22:52.526672082Z');
+      expect(result.repoName).toBe('test-repo');
+      expect(result.tag).toBe('latest');
+      expect(result.lastUpdated).toBe('2020-12-08T00:22:52.526672082Z');
+    });
+
+    it('should handle missing TaggedTimestamp', () => {
+      const responseImage = {
+        RepoName: 'test-repo',
+        Tag: 'latest',
+        LastUpdated: '2020-12-08T00:22:52.526672082Z',
+        Manifests: [],
+        Referrers: [],
+        Size: '1000',
+        DownloadCount: 10,
+        StarCount: 5,
+        Description: 'Test description',
+        IsSigned: false,
+        SignatureInfo: [],
+        Licenses: 'MIT',
+        Labels: [],
+        Title: 'Test Title',
+        Source: 'https://example.com',
+        Documentation: 'Test docs',
+        Vendor: 'Test Vendor',
+        Authors: [],
+        Vulnerabilities: { MaxSeverity: 'NONE', Count: 0 },
+        IsDeletable: true
+      };
+
+      const result = mapToImage(responseImage);
+
+      expect(result.lastTagged).toBeUndefined();
+      expect(result.repoName).toBe('test-repo');
+    });
+  });
+
+  describe('mapToManifest', () => {
+    it('should map manifest data correctly', () => {
+      const responseManifest = {
+        Digest: 'sha256:abc123',
+        ConfigDigest: 'sha256:def456',
+        LastUpdated: '2020-12-08T00:22:52.526672082Z',
+        Size: '75183423',
+        Platform: {
+          Os: 'linux',
+          Arch: 'amd64'
+        },
+        DownloadCount: 10,
+        StarCount: 5,
+        Layers: [],
+        History: [],
+        Vulnerabilities: { MaxSeverity: 'NONE', Count: 0 },
+        Referrers: []
+      };
+
+      const result = mapToManifest(responseManifest);
+
+      expect(result.digest).toBe('sha256:abc123');
+      expect(result.configDigest).toBe('sha256:def456');
+      expect(result.lastUpdated).toBe('2020-12-08T00:22:52.526672082Z');
+      expect(result.size).toBe('75183423');
+      expect(result.platform).toEqual({ Os: 'linux', Arch: 'amd64' });
+      // Verify lastTagged is not included in manifest mapping
+      expect(result.lastTagged).toBeUndefined();
+    });
+  });
+});
+

--- a/src/utilities/objectModels.js
+++ b/src/utilities/objectModels.js
@@ -57,6 +57,7 @@ const mapToImage = (responseImage) => {
     downloadCount: responseImage.DownloadCount,
     starCount: responseImage.StarCount,
     lastUpdated: responseImage.LastUpdated,
+    lastTagged: responseImage.TaggedTimestamp,
     description: responseImage.Description,
     isSigned: responseImage.IsSigned,
     signatureInfo: responseImage.SignatureInfo?.map((sigInfo) => mapSignatureInfo(sigInfo)),

--- a/tests/values/test-constants.js
+++ b/tests/values/test-constants.js
@@ -25,7 +25,7 @@ const endpoints = {
       10 * (pageNumber - 1)
     }%20sortBy:%20${sortCriteria}}%20)%20{Page%20{TotalCount%20ItemCount}%20Repos%20{Name%20LastUpdated%20Size%20Platforms%20{%20Os%20Arch%20}%20IsStarred%20IsBookmarked%20NewestImage%20{%20Tag%20Vulnerabilities%20{MaxSeverity%20Count}%20Description%20IsSigned%20SignatureInfo%20{%20Tool%20IsTrusted%20Author%20}%20Licenses%20Vendor%20Labels%20}%20StarCount%20DownloadCount}}}`,
   image: (name) =>
-    `/v2/_zot/ext/search?query={Image(image:%20%22${name}%22){RepoName%20IsSigned%20SignatureInfo%20{%20Tool%20IsTrusted%20Author%20}%20Vulnerabilities%20{MaxSeverity%20Count}%20%20Referrers%20{MediaType%20ArtifactType%20Size%20Digest%20Annotations{Key%20Value}}%20Tag%20Manifests%20{History%20{Layer%20{Size%20Digest}%20HistoryDescription%20{CreatedBy%20EmptyLayer}}%20Digest%20ConfigDigest%20LastUpdated%20Size%20Platform%20{Os%20Arch}%20Referrers%20{MediaType%20ArtifactType%20Size%20Digest%20Annotations{Key%20Value}}}%20Vendor%20Licenses%20}}`
+    `/v2/_zot/ext/search?query={Image(image:%20%22${name}%22){RepoName%20IsSigned%20SignatureInfo%20{%20Tool%20IsTrusted%20Author%20}%20Vulnerabilities%20{MaxSeverity%20Count}%20%20Referrers%20{MediaType%20ArtifactType%20Size%20Digest%20Annotations{Key%20Value}}%20Tag%20TaggedTimestamp%20Manifests%20{History%20{Layer%20{Size%20Digest}%20HistoryDescription%20{CreatedBy%20EmptyLayer}}%20Digest%20ConfigDigest%20LastUpdated%20Size%20Platform%20{Os%20Arch}%20Referrers%20{MediaType%20ArtifactType%20Size%20Digest%20Annotations{Key%20Value}}}%20Vendor%20Licenses%20}}`
 };
 
 export { hosts, endpoints, sortCriteria, pageSizes };


### PR DESCRIPTION
Display TaggedTimestamp field from GraphQL API as "Last Tagged" in the tag details metadata panel, showing when the image manifest was tagged. "Last Published" becomes "Created"

<img width="1372" height="1224" alt="last_tagged" src="https://github.com/user-attachments/assets/9e85d4cf-bd25-4611-8eb5-dfd88fa8edc8" />


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
