### PR TITLE
feat(auth): use end_session_url from zot logout response

### DIFF
--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -1,7 +1,7 @@
-import { api } from '../api';
+import { api, endpoints } from '../api';
 
 describe('api module', () => {
-  it('should redirect to login if a 401 error is received', () => {
+  const setupLocation = () => {
     Object.defineProperty(window, 'location', {
       writable: true,
       value: { ...window.location, replace: jest.fn() }
@@ -10,8 +10,18 @@ describe('api module', () => {
     location.replace = jest.fn();
     delete window.location;
     window.location = location;
+    return location;
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should redirect to login if a 401 error is received', async () => {
+    const location = setupLocation();
+    jest.spyOn(api, 'post').mockResolvedValue({ data: {} });
     const axiosInstance = api.getAxiosInstance();
-    expect(
+    await expect(
       axiosInstance.interceptors.response.handlers[0].rejected({
         response: { statusText: 'Unauthorized', status: 401 }
       })
@@ -19,5 +29,20 @@ describe('api module', () => {
       response: { statusText: 'Unauthorized', status: 401 }
     });
     expect(location.replace).toHaveBeenCalledWith('/login');
+  });
+
+  it('should not recurse when the 401 originates from the logout endpoint itself', async () => {
+    setupLocation();
+    const postSpy = jest.spyOn(api, 'post').mockResolvedValue({ data: {} });
+    const axiosInstance = api.getAxiosInstance();
+    await expect(
+      axiosInstance.interceptors.response.handlers[0].rejected({
+        config: { url: `https://www.test.com${endpoints.logout}` },
+        response: { statusText: 'Unauthorized', status: 401 }
+      })
+    ).rejects.toMatchObject({
+      response: { statusText: 'Unauthorized', status: 401 }
+    });
+    expect(postSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/api.js
+++ b/src/api.js
@@ -20,9 +20,8 @@ axios.interceptors.response.use(
   (error) => {
     if (error?.response?.status === 401) {
       if (window.location.pathname.includes('/login')) return Promise.reject(error);
-      logoutUser();
-      window.location.replace('/login');
-      return Promise.reject(error);
+      if (error.config?.url && new URL(error.config.url).pathname === endpoints.logout) return Promise.reject(error);
+      return logoutUser().then(() => Promise.reject(error));
     }
   }
 );

--- a/src/utilities/__tests__/authUtilities.test.js
+++ b/src/utilities/__tests__/authUtilities.test.js
@@ -1,0 +1,49 @@
+import { api } from '../../api';
+import { logoutUser } from '../authUtilities';
+
+describe('authUtilities', () => {
+  describe('logoutUser', () => {
+    let replaceMock;
+
+    beforeEach(() => {
+      replaceMock = jest.fn();
+      Object.defineProperty(window, 'location', {
+        writable: true,
+        value: { ...window.location, replace: replaceMock }
+      });
+      localStorage.setItem('authConfig', '{}');
+      document.cookie = 'user=test-user';
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      document.cookie = 'user=; expires=Thu, 01 Jan 1970 00:00:01 GMT';
+      localStorage.clear();
+    });
+
+    it('redirects to endSessionUrl when the response contains a valid URL', async () => {
+      const endSessionUrl = 'https://idp.example.com/logout';
+      jest.spyOn(api, 'post').mockResolvedValue({ data: { endSessionUrl: endSessionUrl } });
+
+      await logoutUser();
+
+      expect(replaceMock).toHaveBeenCalledWith(endSessionUrl);
+    });
+
+    it('falls back to /login when endSessionUrl is malformed', async () => {
+      jest.spyOn(api, 'post').mockResolvedValue({ data: { endSessionUrl: 'not-a-valid-url' } });
+
+      await logoutUser();
+
+      expect(replaceMock).toHaveBeenCalledWith('/login');
+    });
+
+    it('redirects to /login when the response has no endSessionUrl', async () => {
+      jest.spyOn(api, 'post').mockResolvedValue({ data: {} });
+
+      await logoutUser();
+
+      expect(replaceMock).toHaveBeenCalledWith('/login');
+    });
+  });
+});

--- a/src/utilities/authUtilities.js
+++ b/src/utilities/authUtilities.js
@@ -15,16 +15,37 @@ const deleteCookie = (name, path, domain) => {
   }
 };
 
+// Extract endSessionUrl from the logout response and validate it is a
+// well-formed URL, so a malformed value from a misconfigured backend
+// falls through to the /login redirect instead of navigating to garbage.
+/** @param {{ data?: { endSessionUrl?: string } }} response */
+const extractEndSessionUrl = (response) => {
+  const endSessionUrl = response?.data?.endSessionUrl;
+  if (!endSessionUrl) return null;
+  try {
+    const parsed = new URL(endSessionUrl);
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return null;
+    return endSessionUrl;
+  } catch {
+    return null;
+  }
+};
+
 const logoutUser = () => {
-  localStorage.clear();
-  api
+  const finishLogout = (endSessionUrl) => {
+    deleteCookie('user');
+    localStorage.clear();
+    window.location.replace(endSessionUrl || '/login');
+  };
+
+  return api
     .post(`${host()}${endpoints.logout}`)
-    .then(() => {
-      deleteCookie('user');
-      window.location.replace('/login');
+    .then((response) => {
+      finishLogout(extractEndSessionUrl(response));
     })
     .catch((err) => {
-      console.error(err);
+      console.warn(err);
+      finishLogout(null);
     });
 };
 


### PR DESCRIPTION
When POST /zot/auth/logout returns an end_session_url field in its JSON body, navigate the browser to that URL to complete OIDC RP-Initiated Logout at the IdP. Without this, logout only clears the zot session cookie while the IdP session survives, so the next OIDC login silently re-authenticates via SSO.

The existing /login redirect is kept as a fallback for local, LDAP, GitHub OAuth2, and OIDC providers whose discovery document does not advertise an end_session_endpoint.

The backend changes for this PR are implemented in [zot PR](https://github.com/project-zot/zot/pull/3975)

Signed-off-by: Nikita Vakula <programmistov.programmist@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
