### PR TITLE
ci: increase timeout for the zot e2e instance

### DIFF
--- a/tests/zot-config.json
+++ b/tests/zot-config.json
@@ -5,7 +5,9 @@
   },
   "http": {
     "address": "0.0.0.0",
-    "port": "8080"
+    "port": "8080",
+    "readTimeout": "10m",
+    "writeTimeout": "10m"
   },
   "log": {
     "level": "debug",


### PR DESCRIPTION
zot commit 934b22d1 sets default HTTP readTimeout and writeTimeout to 60s in applyDefaultValues when unset. tests/zot-config.json doesn't set them, so long-running ImageListForCVE (~78s+) can exceed the write deadline and produce empty replies. Adding explicit longer timeouts to tests/zot-config.json.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
