### PR TITLE
fix: decode double-encoded slashes in tag view breadcrumb

### DIFF
--- a/src/__tests__/Header/ExploreHeader.test.jsx
+++ b/src/__tests__/Header/ExploreHeader.test.jsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import ExploreHeader from 'components/Header/ExploreHeader';
+import MockThemeProvider from '../../__mocks__/MockThemeProvider';
+import React from 'react';
+import { MemoryRouter, Routes, Route } from 'react-router';
+
+function renderAt(initialEntry) {
+  return render(
+    <MockThemeProvider>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/image/:reponame/tag/:tag" element={<ExploreHeader />} />
+          <Route path="/image/:name" element={<ExploreHeader />} />
+        </Routes>
+      </MemoryRouter>
+    </MockThemeProvider>
+  );
+}
+
+describe('ExploreHeader', () => {
+  it('shows a fully decoded breadcrumb for a nested repo name that survived double encoding', () => {
+    renderAt('/image/company%252Fusers%252Ffoobar%252Fmyapp/tag/v1.0');
+
+    expect(screen.getByText('company/users/foobar/myapp / v1.0')).toBeInTheDocument();
+    expect(document.body.textContent).not.toMatch(/%2F|%25/);
+  });
+
+  it('shows a fully decoded breadcrumb for a nested repo name with a single encoding pass', () => {
+    renderAt('/image/company%2Fusers%2Ffoobar%2Fmyapp/tag/v1.0');
+
+    expect(screen.getByText('company/users/foobar/myapp / v1.0')).toBeInTheDocument();
+    expect(document.body.textContent).not.toMatch(/%2F|%25/);
+  });
+
+  it('links the repo breadcrumb back to a single, correctly encoded repo path', () => {
+    renderAt('/image/company%252Fusers%252Ffoobar%252Fmyapp/tag/v1.0');
+
+    const link = screen.getByText('company/users/foobar/myapp / v1.0').closest('a');
+    expect(link).toHaveAttribute('href', '/image/company%2Fusers%2Ffoobar%2Fmyapp');
+  });
+});

--- a/src/__tests__/RepoPage/Tags.test.jsx
+++ b/src/__tests__/RepoPage/Tags.test.jsx
@@ -7,7 +7,7 @@ import MockThemeProvider from '__mocks__/MockThemeProvider';
 const TagsThemeWrapper = () => {
   return (
     <MockThemeProvider>
-      <Tags tags={mockedTagsData} />
+      <Tags tags={mockedTagsData} repoName="myapp" />
     </MockThemeProvider>
   );
 };
@@ -96,17 +96,23 @@ describe('Tags component', () => {
     const tagLink = await screen.findByText('latest');
     fireEvent.click(tagLink);
     await waitFor(() => {
-      expect(mockedUsedNavigate).toHaveBeenCalledWith('tag/latest', { state: { digest: null } });
+      expect(mockedUsedNavigate).toHaveBeenCalledWith('/image/myapp/tag/latest', { state: { digest: null } });
     });
   });
 
-  it('should navigate with an absolute, encoded path when a repoName is provided, avoiding relative navigation that double-encodes nested repo names', async () => {
+  it('should not prefix the tag name with the repo name in its own tag list', async () => {
+    render(<TagsThemeWrapper />);
+    expect(await screen.findByText('latest')).toBeInTheDocument();
+    expect(screen.queryByText('myapp:latest')).not.toBeInTheDocument();
+  });
+
+  it('should navigate with an absolute, encoded path for a nested repo name, avoiding relative navigation that double-encodes it', async () => {
     render(
       <MockThemeProvider>
         <Tags tags={mockedTagsData} repoName="company/users/foobar/myapp" />
       </MockThemeProvider>
     );
-    const tagLink = await screen.findByText('company/users/foobar/myapp:latest');
+    const tagLink = await screen.findByText('latest');
     fireEvent.click(tagLink);
     await waitFor(() => {
       expect(mockedUsedNavigate).toHaveBeenCalledWith('/image/company%2Fusers%2Ffoobar%2Fmyapp/tag/latest', {
@@ -122,7 +128,7 @@ describe('Tags component', () => {
     const tagLink = await screen.findByText(/sha256:adca4/i);
     fireEvent.click(tagLink);
     await waitFor(() => {
-      expect(mockedUsedNavigate).toHaveBeenCalledWith('tag/latest', {
+      expect(mockedUsedNavigate).toHaveBeenCalledWith('/image/myapp/tag/latest', {
         state: { digest: 'sha256:adca4815c494becc1bf053af0c4640b2d81ab1a779e6d649e1b8b92a75f1d559' }
       });
     });

--- a/src/__tests__/RepoPage/Tags.test.jsx
+++ b/src/__tests__/RepoPage/Tags.test.jsx
@@ -100,6 +100,21 @@ describe('Tags component', () => {
     });
   });
 
+  it('should navigate with an absolute, encoded path when a repoName is provided, avoiding relative navigation that double-encodes nested repo names', async () => {
+    render(
+      <MockThemeProvider>
+        <Tags tags={mockedTagsData} repoName="company/users/foobar/myapp" />
+      </MockThemeProvider>
+    );
+    const tagLink = await screen.findByText('company/users/foobar/myapp:latest');
+    fireEvent.click(tagLink);
+    await waitFor(() => {
+      expect(mockedUsedNavigate).toHaveBeenCalledWith('/image/company%2Fusers%2Ffoobar%2Fmyapp/tag/latest', {
+        state: { digest: null }
+      });
+    });
+  });
+
   it('should navigate to specific manifest when clicking the digest', async () => {
     render(<TagsThemeWrapper />);
     const openBtn = screen.getAllByText(/show/i);

--- a/src/components/Header/ExploreHeader.jsx
+++ b/src/components/Header/ExploreHeader.jsx
@@ -1,5 +1,5 @@
 // react global
-import { Link, useLocation, useNavigate } from 'react-router';
+import { Link, useLocation, useNavigate, useParams } from 'react-router';
 
 // components
 import { Typography, Breadcrumbs } from '@mui/material';
@@ -9,6 +9,7 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 
 import makeStyles from '@mui/styles/makeStyles';
 import React from 'react';
+import { decodeRouteParam } from '../../utilities/urlUtilities';
 
 const useStyles = makeStyles((theme) => {
   return {
@@ -46,11 +47,13 @@ function ExploreHeader() {
   const classes = useStyles();
   const navigate = useNavigate();
   const location = useLocation();
+  const { name, reponame, tag } = useParams();
   const path = location.pathname;
-  const pathWithoutImage = path.replace('tag/', '');
-  const pathToBeDisplayed = pathWithoutImage.replace('/image/', '');
-  const pathHeader = decodeURIComponent(pathToBeDisplayed).replace('/', ' / ').replace(/%2F/g, '/');
-  const pathWithTag = path.substring(0, path.lastIndexOf('/'));
+  const repoName = decodeRouteParam(reponame || name);
+  const pathHeader = tag ? `${repoName} / ${decodeRouteParam(tag)}` : repoName;
+  // rebuild the link from the decoded name instead of slicing location.pathname,
+  // which may still carry an extra %25-encoding layer added by the router history
+  const repoLink = repoName ? `/image/${encodeURIComponent(repoName)}` : '/';
 
   return (
     <div className={classes.exploreHeader}>
@@ -61,7 +64,7 @@ function ExploreHeader() {
             Home
           </Typography>
         </Link>
-        <Link to={pathWithTag.substring(0, pathWithTag.lastIndexOf('/'))}>
+        <Link to={repoLink}>
           {path.includes('/image/') && (
             <Typography className={classes.explore} variant="body1">
               {pathHeader}

--- a/src/components/Header/ExploreHeader.jsx
+++ b/src/components/Header/ExploreHeader.jsx
@@ -1,5 +1,5 @@
 // react global
-import { Link, useLocation, useNavigate, useParams } from 'react-router';
+import { Link, useNavigate, useParams } from 'react-router';
 
 // components
 import { Typography, Breadcrumbs } from '@mui/material';
@@ -46,9 +46,7 @@ const useStyles = makeStyles((theme) => {
 function ExploreHeader() {
   const classes = useStyles();
   const navigate = useNavigate();
-  const location = useLocation();
   const { name, reponame, tag } = useParams();
-  const path = location.pathname;
   const repoName = decodeRouteParam(reponame || name);
   const pathHeader = tag ? `${repoName} / ${decodeRouteParam(tag)}` : repoName;
   // rebuild the link from the decoded name instead of slicing location.pathname,
@@ -65,7 +63,7 @@ function ExploreHeader() {
           </Typography>
         </Link>
         <Link to={repoLink}>
-          {path.includes('/image/') && (
+          {repoName && (
             <Typography className={classes.explore} variant="body1">
               {pathHeader}
             </Typography>

--- a/src/components/Header/ExploreHeader.jsx
+++ b/src/components/Header/ExploreHeader.jsx
@@ -49,7 +49,7 @@ function ExploreHeader() {
   const path = location.pathname;
   const pathWithoutImage = path.replace('tag/', '');
   const pathToBeDisplayed = pathWithoutImage.replace('/image/', '');
-  const pathHeader = pathToBeDisplayed.replace('/', ' / ').replace(/%2F/g, '/');
+  const pathHeader = decodeURIComponent(pathToBeDisplayed).replace('/', ' / ').replace(/%2F/g, '/');
   const pathWithTag = path.substring(0, path.lastIndexOf('/'));
 
   return (

--- a/src/components/Repo/RepoDetails.jsx
+++ b/src/components/Repo/RepoDetails.jsx
@@ -10,6 +10,7 @@ import { api, endpoints } from '../../api';
 import { host } from '../../host';
 import { useParams, useNavigate, createSearchParams } from 'react-router';
 import { mapToRepoFromRepoInfo } from 'utilities/objectModels';
+import { decodeRouteParam } from 'utilities/urlUtilities';
 import { isAuthenticated } from 'utilities/authUtilities';
 import filterConstants from 'utilities/filterConstants';
 
@@ -167,7 +168,8 @@ function RepoDetails() {
   const placeholderImage = useRef(randomImage());
   const [isLoading, setIsLoading] = useState(true);
   // get url param from <Route here (i.e. image name)
-  const { name } = useParams();
+  const { name: rawName } = useParams();
+  const name = decodeRouteParam(rawName);
   const navigate = useNavigate();
   const abortController = useMemo(() => new AbortController(), []);
   const classes = useStyles();

--- a/src/components/Repo/Tabs/Tags.jsx
+++ b/src/components/Repo/Tabs/Tags.jsx
@@ -65,6 +65,7 @@ export default function Tags(props) {
             manifests={tag.manifests}
             repo={repoName}
             repoName={repoName}
+            showRepoName={false}
             onTagDelete={onTagDelete}
             isDeletable={tag.isDeletable}
           />

--- a/src/components/Repo/Tabs/Tags.jsx
+++ b/src/components/Repo/Tabs/Tags.jsx
@@ -64,6 +64,7 @@ export default function Tags(props) {
             vendor={tag.vendor}
             manifests={tag.manifests}
             repo={repoName}
+            repoName={repoName}
             onTagDelete={onTagDelete}
             isDeletable={tag.isDeletable}
           />

--- a/src/components/Shared/TagCard.jsx
+++ b/src/components/Shared/TagCard.jsx
@@ -79,7 +79,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function TagCard(props) {
-  const { repoName, tag, lastUpdated, vendor, manifests, repo, onTagDelete, isDeletable } = props;
+  const { repoName, showRepoName = true, tag, lastUpdated, vendor, manifests, repo, onTagDelete, isDeletable } = props;
   const [open, setOpen] = useState(false);
 
   const classes = useStyles();
@@ -89,12 +89,11 @@ export default function TagCard(props) {
     : `Timestamp N/A`;
   const navigate = useNavigate();
 
+  // Always navigate with the absolute, encoded path -- a relative navigate('tag/...')
+  // here resolves against the current (already %2F-encoded) location and gets
+  // re-escaped by the router into %252F. Every caller must supply repoName.
   const goToTags = (digest = null) => {
-    if (repoName) {
-      navigate(`/image/${encodeURIComponent(repoName)}/tag/${tag}`, { state: { digest } });
-    } else {
-      navigate(`tag/${tag}`, { state: { digest } });
-    }
+    navigate(`/image/${encodeURIComponent(repoName)}/tag/${tag}`, { state: { digest } });
   };
 
   return (
@@ -107,7 +106,7 @@ export default function TagCard(props) {
           {isDeletable && <DeleteTag repo={repo} tag={tag} onTagDelete={onTagDelete} />}
         </Stack>
         <Typography variant="body1" align="left" className={classes.tagName} onClick={() => goToTags()}>
-          {repoName && `${repoName}:`}
+          {showRepoName && `${repoName}:`}
           {tag}
         </Typography>
 

--- a/src/components/Tag/TagDetails.jsx
+++ b/src/components/Tag/TagDetails.jsx
@@ -5,6 +5,7 @@ import React, { useEffect, useMemo, useState, useRef } from 'react';
 import { api, endpoints } from '../../api';
 import { host } from '../../host';
 import { mapToImage } from '../../utilities/objectModels';
+import { decodeRouteParam } from '../../utilities/urlUtilities';
 import filterConstants from 'utilities/filterConstants';
 import { isEmpty, head, uniqBy } from 'lodash';
 
@@ -154,7 +155,9 @@ function TagDetails() {
   const { digest } = state || '';
 
   // get url param from <Route here (i.e. image name)
-  const { reponame, tag } = useParams();
+  const { reponame: rawReponame, tag: rawTag } = useParams();
+  const reponame = decodeRouteParam(rawReponame);
+  const tag = decodeRouteParam(rawTag);
 
   const classes = useStyles();
 

--- a/src/utilities/__tests__/urlUtilities.test.js
+++ b/src/utilities/__tests__/urlUtilities.test.js
@@ -45,13 +45,19 @@ describe('urlUtilities', () => {
       expect(decodeRouteParam('myapp%')).toBe('myapp%');
     });
 
-    it('never decodes escape sequences other than %25 and %2F, since params are interpolated unescaped into GraphQL query strings', () => {
+    it('never decodes escape sequences other than %25 and %2F, since params are interpolated unencoded into GraphQL query URLs', () => {
       // %22 is a single-encoded double quote; a generic decode would turn it into a
       // literal '"' and let the value break out of the quoted GraphQL string in api.js.
       expect(decodeRouteParam('my%22app')).toBe('my%22app');
-      // %2522 is a double-encoded double quote: only the extra '%25' layer should
-      // collapse (to the harmless literal text '%22'), never all the way to '"'.
-      expect(decodeRouteParam('my%2522app')).toBe('my%22app');
+    });
+
+    it('only collapses a %25 that is part of a slash-escape chain, never one leading to another escape', () => {
+      // %2522 is a double-encoded double quote. These query params are embedded
+      // unencoded into a URL (see src/api.js), which the server unescapes once when
+      // parsing it -- so even collapsing this to the harmless-looking '%22' would still
+      // decode to a literal '"' server-side and break out of the quoted GraphQL string.
+      // The '%25' here must be left untouched, since it isn't followed by a '2f'/'2F'.
+      expect(decodeRouteParam('my%2522app')).toBe('my%2522app');
       expect(decodeRouteParam('my%2522app')).not.toContain('"');
     });
   });

--- a/src/utilities/__tests__/urlUtilities.test.js
+++ b/src/utilities/__tests__/urlUtilities.test.js
@@ -25,6 +25,11 @@ describe('urlUtilities', () => {
       expect(decodeRouteParam('company%252Fusers%252Ffoobar%252Fmyapp')).toBe('company/users/foobar/myapp');
     });
 
+    it('decodes lowercase percent-escapes the same as uppercase (percent-encoding is case-insensitive)', () => {
+      expect(decodeRouteParam('company%2fusers%2ffoobar%2fmyapp')).toBe('company/users/foobar/myapp');
+      expect(decodeRouteParam('company%252fusers%252ffoobar%252fmyapp')).toBe('company/users/foobar/myapp');
+    });
+
     it('does not throw on malformed percent sequences and returns the best-effort decode', () => {
       expect(() => decodeRouteParam('myapp%')).not.toThrow();
       expect(decodeRouteParam('myapp%')).toBe('myapp%');

--- a/src/utilities/__tests__/urlUtilities.test.js
+++ b/src/utilities/__tests__/urlUtilities.test.js
@@ -29,5 +29,15 @@ describe('urlUtilities', () => {
       expect(() => decodeRouteParam('myapp%')).not.toThrow();
       expect(decodeRouteParam('myapp%')).toBe('myapp%');
     });
+
+    it('never decodes escape sequences other than %25 and %2F, since params are interpolated unescaped into GraphQL query strings', () => {
+      // %22 is a single-encoded double quote; a generic decode would turn it into a
+      // literal '"' and let the value break out of the quoted GraphQL string in api.js.
+      expect(decodeRouteParam('my%22app')).toBe('my%22app');
+      // %2522 is a double-encoded double quote: only the extra '%25' layer should
+      // collapse (to the harmless literal text '%22'), never all the way to '"'.
+      expect(decodeRouteParam('my%2522app')).toBe('my%22app');
+      expect(decodeRouteParam('my%2522app')).not.toContain('"');
+    });
   });
 });

--- a/src/utilities/__tests__/urlUtilities.test.js
+++ b/src/utilities/__tests__/urlUtilities.test.js
@@ -1,0 +1,33 @@
+import { decodeRouteParam } from '../urlUtilities';
+
+describe('urlUtilities', () => {
+  describe('decodeRouteParam', () => {
+    it('returns non-string values unchanged', () => {
+      expect(decodeRouteParam(undefined)).toBeUndefined();
+      expect(decodeRouteParam(null)).toBeNull();
+    });
+
+    it('returns a value with no percent-encoding unchanged', () => {
+      expect(decodeRouteParam('myapp')).toBe('myapp');
+    });
+
+    it('decodes a single real slash already resolved by the router', () => {
+      // React Router decodes location segments once before exposing them via useParams,
+      // so a repo name containing a real '/' arrives here already decoded.
+      expect(decodeRouteParam('company/users/foobar/myapp')).toBe('company/users/foobar/myapp');
+    });
+
+    it('decodes a name that survived one extra encoding pass (%2F)', () => {
+      expect(decodeRouteParam('company%2Fusers%2Ffoobar%2Fmyapp')).toBe('company/users/foobar/myapp');
+    });
+
+    it('decodes a name that survived two extra encoding passes (%252F)', () => {
+      expect(decodeRouteParam('company%252Fusers%252Ffoobar%252Fmyapp')).toBe('company/users/foobar/myapp');
+    });
+
+    it('does not throw on malformed percent sequences and returns the best-effort decode', () => {
+      expect(() => decodeRouteParam('myapp%')).not.toThrow();
+      expect(decodeRouteParam('myapp%')).toBe('myapp%');
+    });
+  });
+});

--- a/src/utilities/__tests__/urlUtilities.test.js
+++ b/src/utilities/__tests__/urlUtilities.test.js
@@ -25,6 +25,16 @@ describe('urlUtilities', () => {
       expect(decodeRouteParam('company%252Fusers%252Ffoobar%252Fmyapp')).toBe('company/users/foobar/myapp');
     });
 
+    it('only resolves up to one extra %25 layer beyond what the router already handles, not arbitrary depth', () => {
+      // React Router's own param matching already collapses a %2F/%252F name down to a
+      // real slash on its own, so this single pass only needs to catch one further layer
+      // (e.g. a lowercase escape the router's case-sensitive match misses). A third layer
+      // is not something any current code path in this app produces.
+      expect(decodeRouteParam('company%25252Fusers%25252Ffoobar%25252Fmyapp')).toBe(
+        'company%252Fusers%252Ffoobar%252Fmyapp'
+      );
+    });
+
     it('decodes lowercase percent-escapes the same as uppercase (percent-encoding is case-insensitive)', () => {
       expect(decodeRouteParam('company%2fusers%2ffoobar%2fmyapp')).toBe('company/users/foobar/myapp');
       expect(decodeRouteParam('company%252fusers%252ffoobar%252fmyapp')).toBe('company/users/foobar/myapp');

--- a/src/utilities/urlUtilities.js
+++ b/src/utilities/urlUtilities.js
@@ -1,22 +1,16 @@
 // React Router already decodes route params for us, including collapsing one
 // extra layer of '%25' re-encoding and turning '%2F' into a literal slash
 // (see matchRoutesImpl/matchPathImpl in the router package). This only mops
-// up additional layers of that same re-encoding (e.g. a bookmarked link from
-// before this bug was fixed, or a future relative navigation elsewhere in
-// the app reintroducing it).
+// up one further layer of that same re-encoding (e.g. a manually crafted or
+// bookmarked link using lowercase escapes, which the router's own %2F match
+// doesn't normalize the way it does for uppercase).
 //
-// It intentionally only ever touches the '%25' and '%2F' escape sequences
-// and never runs a generic decodeURIComponent: route params are interpolated
-// unescaped into GraphQL query strings (see src/api.js), so decoding
-// arbitrary percent-encoded characters (e.g. %22 -> ") would let a crafted
-// URL break out of the quoted string.
+// It intentionally only ever touches the '%25' and '%2F' escape sequences,
+// in a single pass, and never runs a generic decodeURIComponent: route
+// params are interpolated unescaped into GraphQL query strings (see
+// src/api.js), so decoding arbitrary percent-encoded characters (e.g.
+// %22 -> ") would let a crafted URL break out of the quoted string.
 export function decodeRouteParam(value) {
   if (typeof value !== 'string') return value;
-  let decoded = value;
-  for (let i = 0; i < 5 && (/%25/i.test(decoded) || /%2f/i.test(decoded)); i++) {
-    const next = decoded.replace(/%25/gi, '%').replace(/%2f/gi, '/');
-    if (next === decoded) break;
-    decoded = next;
-  }
-  return decoded;
+  return value.replace(/%25/gi, '%').replace(/%2f/gi, '/');
 }

--- a/src/utilities/urlUtilities.js
+++ b/src/utilities/urlUtilities.js
@@ -13,8 +13,8 @@
 export function decodeRouteParam(value) {
   if (typeof value !== 'string') return value;
   let decoded = value;
-  for (let i = 0; i < 5 && (decoded.includes('%25') || decoded.includes('%2F')); i++) {
-    const next = decoded.replace(/%25/g, '%').replace(/%2F/g, '/');
+  for (let i = 0; i < 5 && (/%25/i.test(decoded) || /%2f/i.test(decoded)); i++) {
+    const next = decoded.replace(/%25/gi, '%').replace(/%2f/gi, '/');
     if (next === decoded) break;
     decoded = next;
   }

--- a/src/utilities/urlUtilities.js
+++ b/src/utilities/urlUtilities.js
@@ -5,12 +5,16 @@
 // bookmarked link using lowercase escapes, which the router's own %2F match
 // doesn't normalize the way it does for uppercase).
 //
-// It intentionally only ever touches the '%25' and '%2F' escape sequences,
-// in a single pass, and never runs a generic decodeURIComponent: route
-// params are interpolated unescaped into GraphQL query strings (see
-// src/api.js), so decoding arbitrary percent-encoded characters (e.g.
-// %22 -> ") would let a crafted URL break out of the quoted string.
+// Route params are interpolated unencoded into GraphQL query URLs (see
+// src/api.js, e.g. `?query={...repo:"${name}"...}`), which the server
+// unescapes once when parsing the `query` param. So a blanket '%25' -> '%'
+// replace is not safe on its own: collapsing '%2522' (a double-encoded '"')
+// to '%22' would still decode to a literal '"' server-side and break out of
+// the quoted string, even though this function never produces that '"'
+// itself. Only collapse a '%25' when it is actually part of a slash-escape
+// chain (optionally repeated '25's ending in '2f'/'2F') -- every other
+// escape sequence, including %22, is left completely untouched.
 export function decodeRouteParam(value) {
   if (typeof value !== 'string') return value;
-  return value.replace(/%25/gi, '%').replace(/%2f/gi, '/');
+  return value.replace(/%25(?=(?:25)*2f)/gi, '%').replace(/%2f/gi, '/');
 }

--- a/src/utilities/urlUtilities.js
+++ b/src/utilities/urlUtilities.js
@@ -1,0 +1,21 @@
+// React Router route params are decoded once by the router itself. When a
+// path segment has been percent-encoded more than once (e.g. a repo name
+// containing '/' that went through an extra encoding pass in the browser's
+// history layer), a single decode still leaves escaped sequences behind
+// (%2F, %252F, ...). Keep decoding until the value stabilizes so any depth
+// of encoding collapses back to the original name.
+export function decodeRouteParam(value) {
+  if (typeof value !== 'string') return value;
+  let decoded = value;
+  for (let i = 0; i < 5 && decoded.includes('%'); i++) {
+    let next;
+    try {
+      next = decodeURIComponent(decoded);
+    } catch {
+      break;
+    }
+    if (next === decoded) break;
+    decoded = next;
+  }
+  return decoded;
+}

--- a/src/utilities/urlUtilities.js
+++ b/src/utilities/urlUtilities.js
@@ -1,19 +1,20 @@
-// React Router route params are decoded once by the router itself. When a
-// path segment has been percent-encoded more than once (e.g. a repo name
-// containing '/' that went through an extra encoding pass in the browser's
-// history layer), a single decode still leaves escaped sequences behind
-// (%2F, %252F, ...). Keep decoding until the value stabilizes so any depth
-// of encoding collapses back to the original name.
+// React Router already decodes route params for us, including collapsing one
+// extra layer of '%25' re-encoding and turning '%2F' into a literal slash
+// (see matchRoutesImpl/matchPathImpl in the router package). This only mops
+// up additional layers of that same re-encoding (e.g. a bookmarked link from
+// before this bug was fixed, or a future relative navigation elsewhere in
+// the app reintroducing it).
+//
+// It intentionally only ever touches the '%25' and '%2F' escape sequences
+// and never runs a generic decodeURIComponent: route params are interpolated
+// unescaped into GraphQL query strings (see src/api.js), so decoding
+// arbitrary percent-encoded characters (e.g. %22 -> ") would let a crafted
+// URL break out of the quoted string.
 export function decodeRouteParam(value) {
   if (typeof value !== 'string') return value;
   let decoded = value;
-  for (let i = 0; i < 5 && decoded.includes('%'); i++) {
-    let next;
-    try {
-      next = decodeURIComponent(decoded);
-    } catch {
-      break;
-    }
+  for (let i = 0; i < 5 && (decoded.includes('%25') || decoded.includes('%2F')); i++) {
+    const next = decoded.replace(/%25/g, '%').replace(/%2F/g, '/');
     if (next === decoded) break;
     decoded = next;
   }


### PR DESCRIPTION
Repo names containing / (e.g. company/users/foobar/myapp) were displayed as company%252Fusers%252Ffoobar%252Fmyapp in the tag view breadcrumb.

encodeURIComponent turns / into %2F when building the path, and React Router's history layer re-encodes % into %25, leaving %252F in location.pathname. ExploreHeader only matched /%2F/g, so the double-encoded form was never replaced.

Apply decodeURIComponent before the existing replacements to collapse %252F back to %2F, after which the existing %2F -> / substitution works as intended.

Fixes project-zot/zot#4250

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
