### PR TITLE
fix(tag): use absolute path when navigating to tag details

### DIFF
--- a/src/__tests__/RepoPage/Tags.test.jsx
+++ b/src/__tests__/RepoPage/Tags.test.jsx
@@ -4,10 +4,10 @@ import Tags from 'components/Repo/Tabs/Tags';
 import React from 'react';
 import MockThemeProvider from '__mocks__/MockThemeProvider';
 
-const TagsThemeWrapper = () => {
+const TagsThemeWrapper = (props) => {
   return (
     <MockThemeProvider>
-      <Tags tags={mockedTagsData} />
+      <Tags tags={mockedTagsData} {...props} />
     </MockThemeProvider>
   );
 };
@@ -97,6 +97,15 @@ describe('Tags component', () => {
     fireEvent.click(tagLink);
     await waitFor(() => {
       expect(mockedUsedNavigate).toHaveBeenCalledWith('tag/latest', { state: { digest: null } });
+    });
+  });
+
+  it('should navigate with an absolute encoded path when the repo name contains a slash', async () => {
+    render(<TagsThemeWrapper repoName="foo/bar" />);
+    const tagLink = await screen.findByText('latest');
+    fireEvent.click(tagLink);
+    await waitFor(() => {
+      expect(mockedUsedNavigate).toHaveBeenCalledWith('/image/foo%2Fbar/tag/latest', { state: { digest: null } });
     });
   });
 

--- a/src/components/Shared/TagCard.jsx
+++ b/src/components/Shared/TagCard.jsx
@@ -90,8 +90,11 @@ export default function TagCard(props) {
   const navigate = useNavigate();
 
   const goToTags = (digest = null) => {
-    if (repoName) {
-      navigate(`/image/${encodeURIComponent(repoName)}/tag/${tag}`, { state: { digest } });
+    // Relative navigation double-encodes repo names containing "/" (%2F becomes
+    // %252F in the URL), so build an absolute path whenever the name is known
+    const targetRepo = repoName || repo;
+    if (targetRepo) {
+      navigate(`/image/${encodeURIComponent(targetRepo)}/tag/${tag}`, { state: { digest } });
     } else {
       navigate(`tag/${tag}`, { state: { digest } });
     }


### PR DESCRIPTION


**What type of PR is this?**

bug

**Which issue does this PR fix**:

N/A

**What does this PR do / Why do we need it**:

Relative navigation from /image/<name> double-encodes repo names containing a slash (%2F becomes %252F in the URL), which breaks the breadcrumb on the tag page.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:

Given a container image `my.repository.tld/foo/bar` with a tag `latest`, when navigating to the `foo/bar` image (`image/foo%2Fbar` address) the breadcrumbs will show `Home / foo/bar`.  The `/` is correct.  If you then navigate to one of the image's tags, the breadcrumbs will show `Home / foo%2F25bar / tag` and the address double encodes the `/` as `image/foo%2F25bar`.

**Testing done on this change**:

Tests have been added

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this change require updates to the CNI daemonset config files to work?**:
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
Fix: navigation from image page no longer encodes repo names twice
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
