### PR TITLE
feat: show zot server version in the account menu

### DIFF
--- a/src/__tests__/Header/UserAccountMenu.test.jsx
+++ b/src/__tests__/Header/UserAccountMenu.test.jsx
@@ -72,4 +72,26 @@ describe('Account Menu', () => {
     fireEvent.click(screen.getByTestId('version-copy-button'));
     expect(writeText).toHaveBeenCalledWith('zot v2.1.0 (commit: abcdef1234567)');
   });
+
+  it('extracts the short hash from a git-describe style commit value', async () => {
+    mockGetServerVersionInfo.mockResolvedValue({ releaseTag: 'v2.1.18', commit: 'v2.1.18-31-g3ff2b93c' });
+
+    render(<UserAccountMenu />);
+    const userIconButton = await screen.findByTestId('user-icon-header-button');
+    fireEvent.click(userIconButton);
+
+    await waitFor(() => expect(screen.getByTestId('version-menu-item')).toBeInTheDocument());
+    expect(screen.getByText('zot v2.1.18 (3ff2b93)')).toBeInTheDocument();
+  });
+
+  it('does not blow up when the commit field is missing', async () => {
+    mockGetServerVersionInfo.mockResolvedValue({ releaseTag: 'v2.1.18' });
+
+    render(<UserAccountMenu />);
+    const userIconButton = await screen.findByTestId('user-icon-header-button');
+    fireEvent.click(userIconButton);
+
+    await waitFor(() => expect(screen.getByTestId('version-menu-item')).toBeInTheDocument());
+    expect(screen.getByText('zot v2.1.18 ()')).toBeInTheDocument();
+  });
 });

--- a/src/__tests__/Header/UserAccountMenu.test.jsx
+++ b/src/__tests__/Header/UserAccountMenu.test.jsx
@@ -1,8 +1,9 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import UserAccountMenu from 'components/Header/UserAccountMenu';
 import React from 'react';
 
 const mockIsApiKeyEnabled = jest.fn();
+const mockGetServerVersionInfo = jest.fn();
 
 jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),
@@ -19,11 +20,20 @@ jest.mock('../../utilities/authUtilities', () => ({
   logoutUser: () => {}
 }));
 
+jest.mock('../../utilities/serverInfo', () => ({
+  getServerVersionInfo: () => mockGetServerVersionInfo()
+}));
+
 describe('Account Menu', () => {
+  beforeEach(() => {
+    mockGetServerVersionInfo.mockResolvedValue({});
+  });
+
   it('displays Api Keys menu item with its divider when the API Keys config is enabled', async () => {
     mockIsApiKeyEnabled.mockReturnValue(true);
     render(<UserAccountMenu />);
-    const userIconButton = await screen.getByTestId('user-icon-header-button');
+    await waitFor(() => expect(mockGetServerVersionInfo).toHaveBeenCalled());
+    const userIconButton = await screen.findByTestId('user-icon-header-button');
     fireEvent.click(userIconButton);
     expect(await screen.queryByTestId('api-keys-menu-item')).toBeInTheDocument();
     expect(await screen.queryByTestId('api-keys-menu-item-divider')).toBeInTheDocument();
@@ -32,9 +42,34 @@ describe('Account Menu', () => {
   it('does not display Api Keys menu item and divider when the API Keys config is disabled', async () => {
     mockIsApiKeyEnabled.mockReturnValue(false);
     render(<UserAccountMenu />);
-    const userIconButton = await screen.getByTestId('user-icon-header-button');
+    await waitFor(() => expect(mockGetServerVersionInfo).toHaveBeenCalled());
+    const userIconButton = await screen.findByTestId('user-icon-header-button');
     fireEvent.click(userIconButton);
     expect(await screen.queryByTestId('api-keys-menu-item')).not.toBeInTheDocument();
     expect(await screen.queryByTestId('api-keys-menu-item-divider')).not.toBeInTheDocument();
+  });
+
+  it('does not display the version menu item when the server version info is unavailable', async () => {
+    render(<UserAccountMenu />);
+    await waitFor(() => expect(mockGetServerVersionInfo).toHaveBeenCalled());
+    const userIconButton = await screen.findByTestId('user-icon-header-button');
+    fireEvent.click(userIconButton);
+    expect(await screen.queryByTestId('version-menu-item')).not.toBeInTheDocument();
+  });
+
+  it('displays a copyable version chip once the server version info loads', async () => {
+    mockGetServerVersionInfo.mockResolvedValue({ releaseTag: 'v2.1.0', commit: 'abcdef1234567' });
+    const writeText = jest.fn();
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<UserAccountMenu />);
+    const userIconButton = await screen.findByTestId('user-icon-header-button');
+    fireEvent.click(userIconButton);
+
+    await waitFor(() => expect(screen.getByTestId('version-menu-item')).toBeInTheDocument());
+    expect(screen.getByText('zot v2.1.0 (abcdef1)')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('version-copy-button'));
+    expect(writeText).toHaveBeenCalledWith('zot v2.1.0 (commit: abcdef1234567)');
   });
 });

--- a/src/components/Header/UserAccountMenu.jsx
+++ b/src/components/Header/UserAccountMenu.jsx
@@ -1,14 +1,25 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
-import { Menu, MenuItem, IconButton, Avatar, Divider } from '@mui/material';
+import { Menu, MenuItem, IconButton, Avatar, Divider, Box, Typography } from '@mui/material';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import CheckIcon from '@mui/icons-material/Check';
 
 import { getLoggedInUser, logoutUser, isApiKeyEnabled } from '../../utilities/authUtilities';
+import { getServerVersionInfo } from '../../utilities/serverInfo';
 import { useNavigate } from 'react-router';
 
 function UserAccountMenu() {
   const [anchorEl, setAnchorEl] = useState(null);
   const openMenu = Boolean(anchorEl);
+  const [versionInfo, setVersionInfo] = useState(null);
+  const [isCopied, setIsCopied] = useState(false);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    getServerVersionInfo()
+      .then(setVersionInfo)
+      .catch(() => console.warn('could not obtain server version info'));
+  }, []);
 
   const apiKeyManagement = () => {
     navigate('/user/apikey');
@@ -20,6 +31,14 @@ function UserAccountMenu() {
 
   const handleUserClose = () => {
     setAnchorEl(null);
+  };
+
+  const handleVersionCopy = (event) => {
+    event.stopPropagation();
+    const { releaseTag, commit } = versionInfo;
+    navigator.clipboard.writeText(`zot ${releaseTag} (commit: ${commit})`);
+    setIsCopied(true);
+    setTimeout(() => setIsCopied(false), 2000);
   };
 
   return (
@@ -51,6 +70,26 @@ function UserAccountMenu() {
         )}
         {isApiKeyEnabled() && <Divider data-testid="api-keys-menu-item-divider" />}
         <MenuItem onClick={logoutUser}>Log out</MenuItem>
+        {versionInfo?.releaseTag && (
+          <>
+            <Divider />
+            <MenuItem disableRipple onClick={(event) => event.stopPropagation()} data-testid="version-menu-item">
+              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%' }}>
+                <Typography variant="caption" color="text.secondary">
+                  zot {versionInfo.releaseTag} ({versionInfo.commit?.slice(0, 7)})
+                </Typography>
+                <IconButton
+                  size="small"
+                  aria-label="copy version"
+                  onClick={handleVersionCopy}
+                  data-testid="version-copy-button"
+                >
+                  {isCopied ? <CheckIcon fontSize="inherit" /> : <ContentCopyIcon fontSize="inherit" />}
+                </IconButton>
+              </Box>
+            </MenuItem>
+          </>
+        )}
       </Menu>
     </>
   );

--- a/src/components/Header/UserAccountMenu.jsx
+++ b/src/components/Header/UserAccountMenu.jsx
@@ -8,6 +8,14 @@ import { getLoggedInUser, logoutUser, isApiKeyEnabled } from '../../utilities/au
 import { getServerVersionInfo } from '../../utilities/serverInfo';
 import { useNavigate } from 'react-router';
 
+// zot's commit field is `git describe` output, e.g. "v2.1.18-31-g3ff2b93c",
+// not a raw SHA, so the short hash has to be pulled from after the "-g".
+const getShortCommit = (commit) => {
+  if (!commit) return commit;
+  const match = commit.match(/-g([0-9a-f]+)$/i);
+  return (match ? match[1] : commit).slice(0, 7);
+};
+
 function UserAccountMenu() {
   const [anchorEl, setAnchorEl] = useState(null);
   const openMenu = Boolean(anchorEl);
@@ -76,7 +84,7 @@ function UserAccountMenu() {
             <MenuItem disableRipple onClick={(event) => event.stopPropagation()} data-testid="version-menu-item">
               <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%' }}>
                 <Typography variant="caption" color="text.secondary">
-                  zot {versionInfo.releaseTag} ({versionInfo.commit?.slice(0, 7)})
+                  zot {versionInfo.releaseTag} ({getShortCommit(versionInfo.commit)})
                 </Typography>
                 <IconButton
                   size="small"

--- a/src/utilities/serverInfo.js
+++ b/src/utilities/serverInfo.js
@@ -1,0 +1,14 @@
+import { api, endpoints } from '../api';
+import { host } from '../host';
+
+// The mgmt endpoint is public (no auth required) and is also used by zli's
+// `zot status` command to report the same build info.
+const getServerVersionInfo = () =>
+  api.get(`${host()}${endpoints.authConfig}`).then((response) => ({
+    releaseTag: response.data?.releaseTag,
+    commit: response.data?.commit,
+    distSpecVersion: response.data?.distSpecVersion,
+    binaryType: response.data?.binaryType
+  }));
+
+export { getServerVersionInfo };


### PR DESCRIPTION
feat: show zot server version in the account menu

Add a copyable version chip to the user account menu, sourced from the existing /v2/_zot/ext/mgmt endpoint (the same one zli status uses) instead of a build-time artifact, so the reported version always matches the running server.

Fixes project-zot/zot#1669