### PR TITLE
fix(login): use mgmt allowAnonymousAccess instead of probing /v2/

### DIFF
--- a/src/__tests__/LoginPage/SignIn.test.jsx
+++ b/src/__tests__/LoginPage/SignIn.test.jsx
@@ -224,4 +224,29 @@ describe('Sign in form', () => {
       expect(mockedUsedNavigate).not.toHaveBeenCalled();
     });
   });
+
+  it('shows continue as guest when mgmt reports anonymous access', async () => {
+    jest.spyOn(api, 'get').mockResolvedValue({
+      status: 200,
+      data: {
+        ...mockMgmtResponse,
+        http: {
+          auth: {
+            ...mockMgmtResponse.http.auth,
+            allowAnonymousAccess: true
+          }
+        }
+      }
+    });
+    render(<SignIn isLoggedIn={false} setIsLoggedIn={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByText('Continue as guest')).toBeInTheDocument();
+    });
+  });
+
+  it('does not show continue as guest without anonymous access', async () => {
+    render(<SignIn isLoggedIn={false} setIsLoggedIn={() => {}} />);
+    await screen.findByLabelText(/^Username/i);
+    expect(screen.queryByText('Continue as guest')).not.toBeInTheDocument();
+  });
 });

--- a/src/__tests__/LoginPage/SignIn.test.jsx
+++ b/src/__tests__/LoginPage/SignIn.test.jsx
@@ -226,7 +226,7 @@ describe('Sign in form', () => {
   });
 
   it('shows continue as guest when mgmt reports anonymous access', async () => {
-    jest.spyOn(api, 'get').mockResolvedValue({
+    const getSpy = jest.spyOn(api, 'get').mockResolvedValue({
       status: 200,
       data: {
         ...mockMgmtResponse,
@@ -242,11 +242,43 @@ describe('Sign in form', () => {
     await waitFor(() => {
       expect(screen.getByText('Continue as guest')).toBeInTheDocument();
     });
+    expect(getSpy).toHaveBeenCalledTimes(1);
+    expect(getSpy).toHaveBeenCalledWith(expect.stringContaining('/v2/_zot/ext/mgmt'), expect.any(AbortSignal));
   });
 
   it('does not show continue as guest without anonymous access', async () => {
     render(<SignIn isLoggedIn={false} setIsLoggedIn={() => {}} />);
     await screen.findByLabelText(/^Username/i);
     expect(screen.queryByText('Continue as guest')).not.toBeInTheDocument();
+    expect(api.get).toHaveBeenCalledTimes(1);
+    expect(api.get).toHaveBeenCalledWith(expect.stringContaining('/v2/_zot/ext/mgmt'), expect.any(AbortSignal));
+  });
+
+  it('does not submit a second login while the first is in flight', async () => {
+    render(<SignIn isLoggedIn={false} setIsLoggedIn={() => {}} />);
+
+    const usernameInput = await screen.findByLabelText(/^Username/i);
+    const passwordInput = await screen.findByLabelText(/^Enter Password/i);
+    await userEvent.type(usernameInput, 'test');
+    await userEvent.type(passwordInput, 'test');
+
+    const getSpy = jest.spyOn(api, 'get').mockReturnValue(new Promise(() => {}));
+    getSpy.mockClear();
+    const submitButton = await screen.findByTestId('basic-auth-submit-btn');
+    fireEvent.click(submitButton);
+    fireEvent.click(submitButton);
+    fireEvent.keyDown(passwordInput, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(submitButton).toBeDisabled();
+    });
+    expect(getSpy).toHaveBeenCalledTimes(1);
+    expect(getSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/\/v2\/$/),
+      expect.any(AbortSignal),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: expect.stringMatching(/^Basic /) })
+      })
+    );
   });
 });

--- a/src/components/Login/SignIn.jsx
+++ b/src/components/Login/SignIn.jsx
@@ -177,16 +177,9 @@ export default function SignIn({ isLoggedIn, setIsLoggedIn, wrapperSetLoading = 
           } else if (response.data?.http?.auth) {
             setAuthMethods(response.data?.http?.auth);
             localStorage.setItem('authConfig', JSON.stringify(response.data?.http?.auth));
+            setIsGuestLoginEnabled(response.data?.http?.auth?.allowAnonymousAccess === true);
             setIsLoading(false);
             wrapperSetLoading(false);
-            api
-              .get(`${host()}${endpoints.status}`)
-              .then((response) => {
-                if (response.status === 200) {
-                  setIsGuestLoginEnabled(true);
-                }
-              })
-              .catch(() => console.log('could not obtain guest login status'));
           }
           setIsLoading(false);
           wrapperSetLoading(false);

--- a/src/components/Login/SignIn.jsx
+++ b/src/components/Login/SignIn.jsx
@@ -1,5 +1,5 @@
 // react global
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 
 // utility
@@ -152,6 +152,7 @@ export default function SignIn({ isLoggedIn, setIsLoggedIn, wrapperSetLoading = 
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [requestProcessing, setRequestProcessing] = useState(false);
+  const requestProcessingRef = useRef(false);
   const [requestError, setRequestError] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [authMethods, setAuthMethods] = useState({});
@@ -196,6 +197,7 @@ export default function SignIn({ isLoggedIn, setIsLoggedIn, wrapperSetLoading = 
   }, []);
 
   const handleBasicAuth = () => {
+    requestProcessingRef.current = true;
     setRequestProcessing(true);
     let cfg = {};
     const token = btoa(username + ':' + password);
@@ -206,9 +208,10 @@ export default function SignIn({ isLoggedIn, setIsLoggedIn, wrapperSetLoading = 
       withCredentials: host() !== window?.location?.origin
     };
     api
-      .get(`${host()}/v2/`, abortController.signal, cfg)
+      .get(`${host()}${endpoints.status}`, abortController.signal, cfg)
       .then((response) => {
         if (response.status === 200) {
+          requestProcessingRef.current = false;
           setRequestProcessing(false);
           setRequestError(false);
           setIsLoggedIn(true);
@@ -216,12 +219,16 @@ export default function SignIn({ isLoggedIn, setIsLoggedIn, wrapperSetLoading = 
         }
       })
       .catch(() => {
+        requestProcessingRef.current = false;
         setRequestError(true);
         setRequestProcessing(false);
       });
   };
 
   const handleBasicAuthSubmit = () => {
+    if (requestProcessingRef.current) {
+      return;
+    }
     setRequestError(false);
     const isUsernameValid = handleUsernameValidation(username);
     const isPasswordValid = handlePasswordValidation(password);
@@ -381,9 +388,11 @@ export default function SignIn({ isLoggedIn, setIsLoggedIn, wrapperSetLoading = 
                 <div>
                   <Button
                     fullWidth
+                    type="button"
                     variant="contained"
                     className={classes.continueButton}
                     onClick={handleClick}
+                    disabled={requestProcessing}
                     data-testid="basic-auth-submit-btn"
                   >
                     Continue
@@ -394,6 +403,7 @@ export default function SignIn({ isLoggedIn, setIsLoggedIn, wrapperSetLoading = 
             {isGuestLoginEnabled && (
               <Button
                 fullWidth
+                type="button"
                 variant="contained"
                 className={classes.continueAsGuestButton}
                 onClick={handleGuestClick}


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix**:

Fixes project-zot/zot#4361

Depends on project-zot/zot#4368 (mgmt must emit `http.auth.allowAnonymousAccess`)

**What does this PR do / Why do we need it**:

The login page probed guest access with an unabortable `GET /v2/`. A delayed 401 (failDelay) after the user had already signed in was handled by the global axios interceptor and called `logoutUser()`.

Guest eligibility now comes from mgmt `http.auth.allowAnonymousAccess` instead of that probe. `GET /v2/` is still used only for the basic-auth credential check.

Also ignore overlapping Continue/Enter submits while that credential check is in flight, so a failed attempt cannot 401 after a successful login has already navigated away.

**Testing done on this change**:

- Unit tests for guest button on/off from mgmt `allowAnonymousAccess`
- Unit test that a second Continue/Enter does not start another `/v2/` login
- Manual: htpasswd login, guest button when anonymous policy is set, no guest button when it is not

**Does this PR introduce any user-facing change?**:

```release-note
Guest login is advertised from mgmt `allowAnonymousAccess` instead of probing GET /v2/. Requires zot with project-zot/zot#4368. Against older zot the guest button is hidden even if anonymous access is configured.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.